### PR TITLE
Unified return types to "EipStatus" and add include guard to generic_networkhandler.h

### DIFF
--- a/source/src/cip/cipclass3connection.c
+++ b/source/src/cip/cipclass3connection.c
@@ -16,9 +16,9 @@ ConnectionObject *GetFreeExplicitConnection(void);
 ConnectionObject g_explicit_connections[OPENER_CIP_NUM_EXPLICIT_CONNS];
 
 /**** Implementation ****/
-int EstablishClass3Connection(ConnectionObject *connection_object,
+EipStatus EstablishClass3Connection(ConnectionObject *connection_object,
                               EipUint16 *extended_error) {
-  int eip_status = kEipStatusOk;
+  EipStatus eip_status = kEipStatusOk;
   EipUint32 produced_connection_id_buffer;
 
   /*TODO add check for transport type trigger */

--- a/source/src/cip/cipclass3connection.h
+++ b/source/src/cip/cipclass3connection.h
@@ -23,7 +23,7 @@
  *    - EIP_OK ... on success
  *    - On an error the general status code to be put into the response
  */
-int EstablishClass3Connection(ConnectionObject *connection_object,
+EipStatus EstablishClass3Connection(ConnectionObject *connection_object,
                               EipUint16 *extended_error);
 
 void InitializeClass3ConnectionData(void);

--- a/source/src/cip/cipioconnection.c
+++ b/source/src/cip/cipioconnection.c
@@ -68,7 +68,7 @@ unsigned int g_config_data_length = 0;
 EipUint32 g_run_idle_state; /**< buffer for holding the run idle information. */
 
 /**** Implementation ****/
-int EstablishIoConnction(ConnectionObject *connection_object,
+EipStatus EstablishIoConnction(ConnectionObject *connection_object,
                          EipUint16 *extended_error) {
   int originator_to_target_connection_type,
       target_to_originator_connection_type;

--- a/source/src/cip/cipioconnection.c
+++ b/source/src/cip/cipioconnection.c
@@ -72,7 +72,7 @@ EipStatus EstablishIoConnction(ConnectionObject *connection_object,
                          EipUint16 *extended_error) {
   int originator_to_target_connection_type,
       target_to_originator_connection_type;
-  int eip_status = kEipStatusOk;
+  EipStatus eip_status = kEipStatusOk;
   CipAttributeStruct *attribute;
   /* currently we allow I/O connections only to assembly objects */
   CipClass *assembly_class = GetCipClass(kCipAssemblyClassCode); /* we don't need to check for zero as this is handled in the connection path parsing */
@@ -716,7 +716,7 @@ EipStatus HandleReceivedIoConnectionData(ConnectionObject *connection_object,
 
 EipStatus OpenCommunicationChannels(ConnectionObject *connection_object) {
 
-  int eip_status = kEipStatusOk;
+  EipStatus eip_status = kEipStatusOk;
   /*get pointer to the CPF data, currently we have just one global instance of the struct. This may change in the future*/
   CipCommonPacketFormatData *common_packet_format_data =
       &g_common_packet_format_data_item;

--- a/source/src/cip/cipioconnection.h
+++ b/source/src/cip/cipioconnection.h
@@ -52,7 +52,7 @@
  *    - EIP_OK ... on success
  *    - On an error the general status code to be put into the response
  */
-int EstablishIoConnction(ConnectionObject *connection_object,
+EipStatus EstablishIoConnction(ConnectionObject *connection_object,
                          EipUint16 *extended_error);
 
 /** @brief Take the data given in the connection object structure and open the necessary communication channels
@@ -63,7 +63,7 @@ int EstablishIoConnction(ConnectionObject *connection_object,
  *    - EIP_OK ... on success
  *    - On an error the general status code to be put into the response
  */
-int OpenCommunicationChannels(ConnectionObject *connection_object);
+EipStatus OpenCommunicationChannels(ConnectionObject *connection_object);
 
 /** @brief close the communication channels of the given connection and remove it
  * from the active connections list.

--- a/source/src/opener_api.h
+++ b/source/src/opener_api.h
@@ -277,7 +277,7 @@ struct connection_object;
  *
  * @return CIP error code
  */
-typedef int (*OpenConnectionFunction)(
+typedef EipStatus (*OpenConnectionFunction)(
     struct connection_object *connection_object, EipUint16 *extended_error_code);
 
 /** @ingroup CIP_API

--- a/source/src/ports/generic_networkhandler.h
+++ b/source/src/ports/generic_networkhandler.h
@@ -11,6 +11,9 @@
  *  @attention This file should only be used for implementing port-specific network handlers and is not intended to grant other parts of the OpENer access to the network layer
  */
 
+#ifndef GENERIC_NETWORKHANDLER_H_
+#define GENERIC_NETWORKHANDLER_H_
+
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
@@ -92,3 +95,5 @@ EipBool8 CheckSocketSet(int socket);
  * @return Highest socket id from the provided sockets
  */
 int GetMaxSocket(int socket1, int socket2, int socket3, int socket4);
+
+#endif /* GENERIC_NETWORKHANDLER_H_ */


### PR DESCRIPTION
Some of the cip functions where declared and/or implemented with return type int, while returning EipStatus. This was inconsistent with the rest.
generic_networkhandler.h had no include guard. Don't know if it's realy necessary, but it's probably better to have one.