### PR TITLE
Undefined behaviour due to assignment of int to enum-type

### DIFF
--- a/source/src/enet_encap/encap.c
+++ b/source/src/enet_encap/encap.c
@@ -151,7 +151,7 @@ void EncapsulationInit(void) {
 
 int HandleReceivedExplictTcpData(int socket, EipUint8 *buffer,
                                  unsigned int length, int *remaining_bytes) {
-  EipStatus return_value = kEipStatusOk;
+  int return_value = kEipStatusOk;
   EncapsulationData encapsulation_data;
   /* eat the encapsulation header*/
   /* the structure contains a pointer to the encapsulated data*/
@@ -221,7 +221,7 @@ int HandleReceivedExplictTcpData(int socket, EipUint8 *buffer,
 int HandleReceivedExplictUdpData(int socket, struct sockaddr_in *from_address,
                                  EipUint8 *buffer, unsigned int buffer_length,
                                  int *number_of_remaining_bytes, int unicast) {
-  EipStatus status = kEipStatusOk;
+  int status = kEipStatusOk;
   EncapsulationData encapsulation_data;
   /* eat the encapsulation header*/
   /* the structure contains a pointer to the encapsulated data*/

--- a/source/src/typedefs.h
+++ b/source/src/typedefs.h
@@ -106,12 +106,14 @@ typedef enum {
 } UdpCommuncationDirection;
 
 #ifndef __cplusplus
-/** @brief If we don't have C++ define a C++ -like "bool" keyword defines
+#if !defined(__bool_true_false_are_defined)
+/** @brief If not yet done (through C++ or stdbool.h (C99)), define "true" and "false" keywords
  */
 typedef enum {
   false = 0, /**< defines "false" as 0 */
   true = 1 /**< defines "true" as 1 */
 } BoolKeywords;
+#endif /* __bool_true_false_are_defined */
 #endif /* __cplusplus */
 
 #endif /* OPENER_TYPEDEFS_H_ */


### PR DESCRIPTION
The assignment of int values to an enum-type, beyond the range of all members in that type may lead (and has for me) to undefined behaviour. From C Standard (C99):

> 6.7.2.2 Enumeration specifiers
> [...]
> Each enumerated type shall be compatible with char, a signed integer type, or an unsigned integer type. The choice of type is implementation-defined, but shall be capable of representing the values of all the members of the enumeration.