### PR TITLE
Fix encapsulation inactivity socket timeout.

### DIFF
--- a/source/src/ports/generic_networkhandler.c
+++ b/source/src/ports/generic_networkhandler.c
@@ -893,7 +893,7 @@ void CheckEncapsulationInactivity(int socket_handle) {
       MilliSeconds diffms = g_actual_time - SocketTimerGetLastUpdate(
         socket_timer);
 
-      if (diffms >= g_encapsulation_inactivity_timeout) {
+    if (diffms >= (1000UL * (MilliSeconds)g_encapsulation_inactivity_timeout)) {
         CloseSocket(socket_handle);
         CloseSession(socket_handle);
       }


### PR DESCRIPTION
g_encapsulation_inactivity_timeout is in units of seconds, but was being
used as milliseconds.