### PR TITLE
Update cipconnectionobject.h

### DIFF
--- a/source/src/cip/cipconnectionobject.h
+++ b/source/src/cip/cipconnectionobject.h
@@ -106,11 +106,11 @@ struct cip_connection_object {
   CipUsint instance_type; /*< Attribute 2 */
   CipByte transport_class_trigger; /*< Attribute 3 */
   /* Attribute 4-6 only for device net*/
-  CipUdint produced_connection_size; /*< Attribute 7 - Limits produced connection size - for explicit messaging 0xFFFF means no predefined limit */
-  CipUdint consumed_connection_size; /*< Attribute 8 - Limits produced connection size - for explicit messaging 0xFFFF means no predefined limit */
+  CipUint produced_connection_size; /*< Attribute 7 - Limits produced connection size - for explicit messaging 0xFFFF means no predefined limit */
+  CipUint consumed_connection_size; /*< Attribute 8 - Limits produced connection size - for explicit messaging 0xFFFF means no predefined limit */
   CipUint expected_packet_rate; /*< Attribute 9 - Resolution in Milliseconds */
-  CipUint cip_produced_connection_id; /*< Attribute 10 */
-  CipUint cip_consumed_connection_id; /*< Attribute 11 */
+  CipUdint cip_produced_connection_id; /*< Attribute 10 */
+  CipUdint cip_consumed_connection_id; /*< Attribute 11 */
   CipUsint watchdog_timeout_action; /*< Attribute 12 */
   CipUint produced_connection_path_length; /*< Attribute 13 */
   CipOctet *produced_connection_path; /*< Attribute 14 */

--- a/source/src/cip/cipconnectionobject.h
+++ b/source/src/cip/cipconnectionobject.h
@@ -106,8 +106,8 @@ struct cip_connection_object {
   CipUsint instance_type; /*< Attribute 2 */
   CipByte transport_class_trigger; /*< Attribute 3 */
   /* Attribute 4-6 only for device net*/
-  CipUint produced_connection_size; /*< Attribute 7 - Limits produced connection size - for explicit messaging 0xFFFF means no predefined limit */
-  CipUint consumed_connection_size; /*< Attribute 8 - Limits produced connection size - for explicit messaging 0xFFFF means no predefined limit */
+  CipUdint produced_connection_size; /*< Attribute 7 - Limits produced connection size - for explicit messaging 0xFFFF means no predefined limit */
+  CipUdint consumed_connection_size; /*< Attribute 8 - Limits produced connection size - for explicit messaging 0xFFFF means no predefined limit */
   CipUint expected_packet_rate; /*< Attribute 9 - Resolution in Milliseconds */
   CipUint cip_produced_connection_id; /*< Attribute 10 */
   CipUint cip_consumed_connection_id; /*< Attribute 11 */


### PR DESCRIPTION
Produced and Consumed connection ID should be of size CipUdint to properly store connection ID greater than 0xFFFF. 

cipconnectionobject.c
CipUdint ConnectionObjectGetCipProducedConnectionID(
  const CipConnectionObject *const connection_object) {
  return connection_object->cip_produced_connection_id;
}

void ConnectionObjectSetCipProducedConnectionID(
  CipConnectionObject *const connection_object,
  const CipUdint
  cip_produced_connection_id) {
  connection_object->cip_produced_connection_id = cip_produced_connection_id;
}