### PR TITLE
Update generic_networkhandler.c

### DIFF
--- a/source/src/ports/generic_networkhandler.c
+++ b/source/src/ports/generic_networkhandler.c
@@ -189,7 +189,7 @@ EipStatus NetworkHandlerInitialize(void) {
     return kEipStatusError;
   }
 
-  struct sockaddr_in global_broadcast_address = { .sin_family = AF_INET,
+  struct sockaddr_in global_broadcast_address = { .sin_family = {AF_INET},
                                                   .sin_port = htons(
                                                     kOpenerEthernetPort),
                                                   .sin_addr.s_addr = htonl(


### PR DESCRIPTION
changed to {INADDR_ANY} because sockaddr_in.sin_addr is only a struct under linux, gcc throws missing initializer braces.  Caused erroneous execution under linux related to issue #154  