### PR TITLE
Fix mingw call to configureDomain and missing types

### DIFF
--- a/source/src/ports/MINGW/main.c
+++ b/source/src/ports/MINGW/main.c
@@ -46,7 +46,7 @@ int main(int argc,
                                CipConnectionObjectListArrayAllocator,
                                CipConnectionObjectListArrayFree);
     /* fetch Internet address info from the platform */
-    ConfigureDomainName(arg[1] );
+    ConfigureDomainName();
     ConfigureHostName();
     ConfigureNetworkInterface(arg[1] );
   }

--- a/source/src/ports/MINGW/sample_application/opener_user_conf.h
+++ b/source/src/ports/MINGW/sample_application/opener_user_conf.h
@@ -22,6 +22,8 @@
  *    - inet_addr
  */
 
+ #include "typedefs.h"
+
 typedef unsigned short in_port_t;
 
 /** @brief Identity configuration of the device */
@@ -114,7 +116,7 @@ static const int kOpenerProducedDataHasRunIdleHeader = 0;
                 __LINE__); \
       while(1) {;} \
     } \
-  } while(0)
+  } while(0);
 
 /* else use standard assert() */
 //#include <assert.h>


### PR DESCRIPTION
Fix a few problems with MINGW. The compile failes with traces enabled. This may be a problem with POSIX/WIN builds also.  The ConfigureDomain call should have no parameters, and the typedefs.h must be included to avoid errors in other files.