### PR TITLE
Fix warnings and compilation

### DIFF
--- a/source/src/cip/ciptcpipinterface.c
+++ b/source/src/cip/ciptcpipinterface.c
@@ -226,9 +226,9 @@ void ShutdownTcpIpInterface(void) {
 }
 
 EipStatus GetAttributeSingleTcpIpInterface(
-  CipInstance *const RESTRICT instance,
-  CipMessageRouterRequest *RESTRICT const message_router_request,
-  CipMessageRouterResponse *RESTRICT const message_router_response,
+  CipInstance *instance,
+  CipMessageRouterRequest *message_router_request,
+  CipMessageRouterResponse *message_router_response,
   struct sockaddr *originator_address,
   const int encapsulation_session) {
 

--- a/source/src/ports/WIN32/networkhandler.c
+++ b/source/src/ports/WIN32/networkhandler.c
@@ -25,7 +25,7 @@ MicroSeconds GetMicroSeconds() {
 }
 
 MilliSeconds GetMilliSeconds(void) {
-  return (MilliSeconds) (getMicroSeconds() / 1000ULL);
+  return (MilliSeconds) (GetMicroSeconds() / 1000ULL);
 }
 
 EipStatus NetworkHandlerInitializePlatform(void) {

--- a/source/src/utils/doublylinkedlist.c
+++ b/source/src/utils/doublylinkedlist.c
@@ -35,7 +35,7 @@ void DoublyLinkedListDestroy(DoublyLinkedList *list) {
 
 DoublyLinkedListNode *DoublyLinkedListNodeCreate(
   const void *const data,
-  NodeMemoryAllocator const
+  NodeMemoryAllocator
   allocator) {
   DoublyLinkedListNode *new_node = (DoublyLinkedListNode *)allocator();
   new_node->data = (void *)data;


### PR DESCRIPTION
Unfortunately I am not even sure if this fix is right. For now, just focusing on getting things to compile with the Visual Studio compiler.

I didn't analyse if it was correct to remove or add the const/RESTRICT references but just brought them in line with surrounding code.