### PR TITLE
Fix DNS server address retrieval.

### DIFF
--- a/source/src/cip/ciptypes.h
+++ b/source/src/cip/ciptypes.h
@@ -290,6 +290,8 @@ typedef struct cip_service_struct {
 
 /**
  * @brief Struct for saving TCP/IP interface information
+ *
+ * All addresses are stored in network byte order.
  */
 typedef struct {
   CipUdint ip_address;

--- a/source/src/ports/WIN32/networkconfig.c
+++ b/source/src/ports/WIN32/networkconfig.c
@@ -27,7 +27,7 @@
 
 
 static CipUdint GetDnsServerAddress(
-    const IP_ADAPTER_DNS_SERVER_ADDRESS_XP const * RESTRICT in);
+    const IP_ADAPTER_DNS_SERVER_ADDRESS_XP * const RESTRICT in);
 
 
 void ConfigureIpMacAddress(const CipUint interface_index) {
@@ -224,7 +224,7 @@ void ConfigureDomainName(const CipUint interface_index) {
 * @return The IPv4 address in network byte order.
 */
 static CipUdint GetDnsServerAddress(
-    const IP_ADAPTER_DNS_SERVER_ADDRESS_XP const * RESTRICT in) {
+    const IP_ADAPTER_DNS_SERVER_ADDRESS_XP * const RESTRICT in) {
   return (in != NULL)
              ? ((SOCKADDR_IN *)in->Address.lpSockaddr)->sin_addr.S_un.S_addr
              : 0;


### PR DESCRIPTION
The interface_configuration_ struct stores DNS addresses as CipUdint,
not strings, so network-to-presentation(Ntop) conversion is wrong. Also,
this fixes a problem with selecting an adapter with less than two DNS
servers configured, as the FirstDnsServerAddress linked list may be less
than two entries long.