### PR TITLE
Fix yocto build

### DIFF
--- a/source/src/cip/cipidentity.h
+++ b/source/src/cip/cipidentity.h
@@ -71,7 +71,7 @@ typedef struct {
 
 
 /* global public variables */
-CipIdentityObject g_identity;
+extern CipIdentityObject g_identity;
 
 
 /* public functions */

--- a/source/src/cip/cipqos.c
+++ b/source/src/cip/cipqos.c
@@ -35,7 +35,7 @@ CipQosObject g_qos = {
   .dscp.scheduled = DEFAULT_DSCP_SCHEDULED,
   .dscp.high = DEFAULT_DSCP_HIGH,
   .dscp.low = DEFAULT_DSCP_LOW,
-  .dscp.explicit = DEFAULT_DSCP_EXPLICIT
+  .dscp.explicit_msg = DEFAULT_DSCP_EXPLICIT
 };
 
 /** @brief Active set of DSCP data inherits its data from the QoS object on boot-up
@@ -51,7 +51,7 @@ static CipQosDscpValues s_active_dscp = {
   .scheduled = DEFAULT_DSCP_SCHEDULED,
   .high = DEFAULT_DSCP_HIGH,
   .low = DEFAULT_DSCP_LOW,
-  .explicit = DEFAULT_DSCP_EXPLICIT
+  .explicit_msg = DEFAULT_DSCP_EXPLICIT
 };
 
 /************** Functions ****************************************/
@@ -136,7 +136,7 @@ CipUsint CipQosGetDscpPriority(ConnectionObjectPriority priority) {
       break;
     case kConnectionObjectPriorityExplicit: /* fall through */
     default:
-      priority_value = s_active_dscp.explicit;
+      priority_value = s_active_dscp.explicit_msg;
       break;
   }
   return priority_value;
@@ -210,7 +210,7 @@ EipStatus CipQoSInit() {
                   8,
                   kCipUsint,
                   EncodeCipUsint,
-                  (void *) &g_qos.dscp.explicit,
+                  (void *) &g_qos.dscp.explicit_msg,
                   kGetableSingle | kSetable | kNvDataFunc);
 
   InsertService(qos_class, kGetAttributeSingle, &GetAttributeSingle,
@@ -233,7 +233,7 @@ void CipQosResetAttributesToDefaultValues(void) {
     .scheduled = DEFAULT_DSCP_SCHEDULED,
     .high = DEFAULT_DSCP_HIGH,
     .low = DEFAULT_DSCP_LOW,
-    .explicit = DEFAULT_DSCP_EXPLICIT
+    .explicit_msg = DEFAULT_DSCP_EXPLICIT
   };
   g_qos.q_frames_enable = false;
   g_qos.dscp = kDefaultValues;

--- a/source/src/cip/cipqos.h
+++ b/source/src/cip/cipqos.h
@@ -29,7 +29,7 @@ typedef struct cip_qos_dscp_values {
   CipUsint scheduled; /**< Attr. #5: DSCP value for CIP transport class 0/1 Scheduled priority messages */
   CipUsint high; /**< Attr. #6: DSCP value for CIP transport class 0/1 High priority messages */
   CipUsint low; /**< Attr. #7: DSCP value for CIP transport class 0/1 low priority messages */
-  CipUsint explicit; /**< Attr. #8: DSCP value for CIP explicit messages (transport class 2/3 and UCMM)
+  CipUsint explicit_msg; /**< Attr. #8: DSCP value for CIP explicit messages (transport class 2/3 and UCMM)
                                         and all other EtherNet/IP encapsulation messages */
 } CipQosDscpValues;
 

--- a/source/src/ports/nvdata/nvqos.c
+++ b/source/src/ports/nvdata/nvqos.c
@@ -59,7 +59,7 @@ int NvQosLoad(CipQosObject *p_qos) {
       p_qos->dscp.scheduled = dscp_scheduled;
       p_qos->dscp.high = dscp_high;
       p_qos->dscp.low = dscp_low;
-      p_qos->dscp.explicit = dscp_explicit;
+      p_qos->dscp.explicit_msg = dscp_explicit;
     } else {
       eip_status = kEipStatusError;
     }
@@ -84,7 +84,7 @@ EipStatus NvQosStore(const CipQosObject *p_qos) {
                      p_qos->dscp.scheduled,
                      p_qos->dscp.high,
                      p_qos->dscp.low,
-                     p_qos->dscp.explicit) ) {
+                     p_qos->dscp.explicit_msg) ) {
       eip_status = kEipStatusError;
     }
 


### PR DESCRIPTION
`CipUsint explicit;` fails to compile with following error

```
/usr/include/cip/cipqos.h:32:12: error: declaration does not declare anything [-fpermissive]
   32 |   CipUsint explicit; /**< Attr. #8: DSCP value for CIP explicit messages (transport class 2/3 and UCMM)
      |            ^~~~~~~~
```

When using OpENer as a library, separate sample configuration link fails with 
```
ld: /usr/lib/../lib/libCIP.a(cipidentity.c.o):(.data.rel.local+0x0): multiple definition of `g_identity'; CMakeFiles/cube-cip.dir/src/CIPApplication.cpp.o:/usr/include/cip/cipidentity.h:74: first defined here
| collect2: error: ld returned 1 exit status
```

Signed-off-by: Vincent Prince <vincent.prince.fr@gmail.com>