### PR TITLE
Update sample_application to work with example eds file

### DIFF
--- a/source/src/ports/MINGW/sample_application/sampleapplication.c
+++ b/source/src/ports/MINGW/sample_application/sampleapplication.c
@@ -20,7 +20,7 @@
 
 #define DEMO_APP_INPUT_ASSEMBLY_NUM                100 //0x064
 #define DEMO_APP_OUTPUT_ASSEMBLY_NUM               150 //0x096
-#define DEMO_APP_CONFIG_ASSEMBLY_NUM               1 //0x001
+#define DEMO_APP_CONFIG_ASSEMBLY_NUM               151 //0x097
 #define DEMO_APP_HEARTBEAT_INPUT_ONLY_ASSEMBLY_NUM  152 //0x098
 #define DEMO_APP_HEARTBEAT_LISTEN_ONLY_ASSEMBLY_NUM 153 //0x099
 #define DEMO_APP_EXPLICT_ASSEMBLY_NUM              154 //0x09A
@@ -29,8 +29,8 @@
 
 /* global variables for demo application (4 assembly data fields)  ************/
 
-EipUint8 g_assembly_data064[40]; /* Input */
-EipUint8 g_assembly_data096[40]; /* Output */
+EipUint8 g_assembly_data064[32]; /* Input */
+EipUint8 g_assembly_data096[32]; /* Output */
 EipUint8 g_assembly_data097[10]; /* Config */
 EipUint8 g_assembly_data09A[32]; /* Explicit */
 


### PR DESCRIPTION
The input and output size were changed to 32, and the output assembly number was modified to 151 to match the opener_sample_app.eds file.