### PR TITLE
member name changed in struct CipMessageRouterRequest

### DIFF
--- a/source/src/cip/cipassembly.c
+++ b/source/src/cip/cipassembly.c
@@ -177,13 +177,13 @@ int DecodeCipAssemblyAttribute3(CipByteArray *const data,
 	OPENER_TRACE_INFO(" -> set Assembly attribute byte array\r\n");
 	CipByteArray *cip_byte_array = data;
 
-	if (message_router_request->request_path_size < data->length) {
+	if (message_router_request->request_data_size < data->length) {
 		OPENER_TRACE_INFO(
 				"DecodeCipByteArray: not enough data received.\n");
 		message_router_response->general_status = kCipErrorNotEnoughData;
 		return number_of_decoded_bytes;
 	}
-	if (message_router_request->request_path_size > data->length) {
+	if (message_router_request->request_data_size > data->length) {
 		OPENER_TRACE_INFO(
 				"DecodeCipByteArray: too much data received.\n");
 		message_router_response->general_status = kCipErrorTooMuchData;

--- a/source/src/cip/cipcommon.c
+++ b/source/src/cip/cipcommon.c
@@ -646,13 +646,13 @@ int DecodeCipByteArray(CipByteArray *const data, const CipMessageRouterRequest *
   OPENER_TRACE_INFO(" -> set attribute byte array\r\n");
   CipByteArray *cip_byte_array = data;
 
-  if(message_router_request->request_path_size < data->length) {
+  if(message_router_request->request_data_size < data->length) {
     OPENER_TRACE_INFO(
         "DecodeCipByteArray: not enough data received.\n");
     message_router_response->general_status = kCipErrorNotEnoughData;
     return number_of_decoded_bytes;
   }
-  if(message_router_request->request_path_size > data->length) {
+  if(message_router_request->request_data_size > data->length) {
     OPENER_TRACE_INFO(
         "DecodeCipByteArray: too much data received.\n");
     message_router_response->general_status = kCipErrorTooMuchData;

--- a/source/src/cip/cipconnectionmanager.c
+++ b/source/src/cip/cipconnectionmanager.c
@@ -1300,14 +1300,14 @@ EipUint8 ParseConnectionPath(CipConnectionObject *connection_object,
   }
 
   if( (header_length + remaining_path * 2) <
-      message_router_request->request_path_size ) {
+      message_router_request->request_data_size ) {
     /* the received packet is larger than the data in the path */
     *extended_error = 0;
     return kCipErrorTooMuchData;
   }
 
   if( (header_length + remaining_path * 2) >
-      message_router_request->request_path_size ) {
+      message_router_request->request_data_size ) {
     /*there is not enough data in received packet */
     *extended_error = 0;
     OPENER_TRACE_INFO("Message not long enough for path\n");

--- a/source/src/cip/cipidentity.c
+++ b/source/src/cip/cipidentity.c
@@ -149,12 +149,12 @@ static EipStatus Reset(CipInstance *instance,
   message_router_response->size_of_additional_status = 0;
   message_router_response->general_status = kCipErrorSuccess;
 
-  if (message_router_request->request_path_size > 1) {
+  if (message_router_request->request_data_size > 1) {
     message_router_response->general_status = kCipErrorTooMuchData;
   }
   else {
     CipOctet reset_type = 0;  /* The default type if type parameter was omitted. */
-    if (message_router_request->request_path_size == 1) {
+    if (message_router_request->request_data_size == 1) {
       reset_type = message_router_request->data[0];
     }
     switch (reset_type) {

--- a/source/src/cip/cipmessagerouter.c
+++ b/source/src/cip/cipmessagerouter.c
@@ -259,10 +259,10 @@ CipError CreateMessageRouterRequestStructure(
   }
 
   message_router_request->data = data;
-  message_router_request->request_path_size = data_length
+  message_router_request->request_data_size = data_length
                                               - number_of_decoded_bytes;
 
-  if (message_router_request->request_path_size < 0) {
+  if (message_router_request->request_data_size < 0) {
     return kCipErrorPathSizeInvalid;
   } else {
     return kCipErrorSuccess;

--- a/source/src/cip/ciptypes.h
+++ b/source/src/cip/ciptypes.h
@@ -255,7 +255,7 @@ typedef struct {
 typedef struct {
   CipUsint service;
   CipEpath request_path;
-  EipInt16 request_path_size;
+  EipInt16 request_data_size;
   const CipOctet *data;
 } CipMessageRouterRequest;
 


### PR DESCRIPTION
CipMessageRouterRequest struct:  "request_path_size" renamed as "request_data_size" - indicates size of data in the request