### PR TITLE
Warn on open connection failures

### DIFF
--- a/source/src/cip/cipconnectionmanager.c
+++ b/source/src/cip/cipconnectionmanager.c
@@ -1006,7 +1006,7 @@ EipStatus AssembleForwardOpenResponse(CipConnectionObject *connection_object,
                      &message_router_response->message);
   } else {
     /* we have an connection creation error */
-    OPENER_TRACE_INFO("AssembleForwardOpenResponse: sending error response\n");
+    OPENER_TRACE_WARN("AssembleForwardOpenResponse: sending error response, general/extended status=%d/%d\n", general_status, extended_status);
     ConnectionObjectSetState(connection_object,
                              kConnectionObjectStateNonExistent);
     /* Expected data length is 10 octets */


### PR DESCRIPTION
Increase the condition reporting on open connection failures from
informative to warn. Also include the extended status in the warning
for easier triage on what caused the connection failure in the first
place.

This PR is motivated due to numerous times messing up the connection by mismatching assembly parameters like size or number. The informative level is verbose and not appropriate to enable in production setup. The warning level is more appropriate for this relatively rare condition.

Related, there should be an option to have the logging level runtime switchable.