### PR TITLE
APIs for setting Run/Idle header on O->T and T->O frames

### DIFF
--- a/source/src/opener_api.h
+++ b/source/src/opener_api.h
@@ -111,6 +111,30 @@ EipStatus CipStackInit(const EipUint16 unique_connection_id);
 void ShutdownCipStack(void);
 
 /** @ingroup CIP_API
+ * @brief Enable the Run/Idle header for consumed (O->T) cyclic data
+ * @param onoff if set (default), OpENer expects 4 byte Run/Idle header from scanner
+ */
+void CipRunIdleHeaderSetO2T(bool onoff);
+
+/** @ingroup CIP_API
+ * @brief Get current setting of the O->T Run/Idle header
+ * @return current setting of the O->T Run/Idle header
+ */
+bool CipRunIdleHeaderGetO2T(void);
+
+/** @ingroup CIP_API
+ * @brief Enable the Run/Idle header for produced (T->O) cyclic data
+ * @param onoff if set (not default), OpENer includes a 4 byte Run/Idle header in responses to scanner
+ */
+void CipRunIdleHeaderSetT2O(bool onoff);
+
+/** @ingroup CIP_API
+ * @brief Get current setting of the T->O Run/Idle header
+ * @return current setting of the T->O Run/Idle header
+ */
+bool CipRunIdleHeaderGetT2O(void);
+
+/** @ingroup CIP_API
  * @brief Get a pointer to a CIP object with given class code
  *
  * @param class_code class code of the object to retrieve


### PR DESCRIPTION
This change adds APIs for set and query if the OpENer behavior wrt.  the Run/Idle header on both received and sent CIP cyclic data.  In effect, this makes it possible to build your adapter once and support different types of scanners.  Enabling use of Open Source scanners like [EIPScanner](https://github.com/nimbuscontrols/EIPScanner) for testing your adapter before deploying at a customer site which may require a different behavior.

Previously these were a compile-time options, which is still honored by setting the defaults based on these cmake options.