### PR TITLE
New APIs for setting Identity object attributes at runtime

### DIFF
--- a/source/src/cip/cipidentity.c
+++ b/source/src/cip/cipidentity.c
@@ -92,7 +92,7 @@ CipUint GetDeviceVendorId(void) {
 }
 
 /* The Doxygen comment is with the function's prototype in opener_api.h. */
-void SetDeviceProductName(const CipOctet *product_name) {
+void SetDeviceProductName(const char *product_name) {
   if (!product_name)
     return;
 

--- a/source/src/cip/cipidentity.c
+++ b/source/src/cip/cipidentity.c
@@ -66,6 +66,16 @@ void SetDeviceSerialNumber(const EipUint32 serial_number) {
 }
 
 /* The Doxygen comment is with the function's prototype in opener_api.h. */
+void SetDeviceType(const EipUint16 type) {
+  g_identity.device_type = type;
+}
+
+/* The Doxygen comment is with the function's prototype in opener_api.h. */
+void SetDeviceProductCode(const EipUint16 code) {
+  g_identity.product_code = code;
+}
+
+/* The Doxygen comment is with the function's prototype in opener_api.h. */
 void SetDeviceStatus(const CipWord status) {
   g_identity.status = status;
   g_identity.ext_status = status & kExtStatusMask;

--- a/source/src/cip/cipidentity.c
+++ b/source/src/cip/cipidentity.c
@@ -55,6 +55,12 @@ CipIdentityObject g_identity = { .vendor_id = OPENER_DEVICE_VENDOR_ID, /* Attrib
                                  };
 
 /* The Doxygen comment is with the function's prototype in opener_api.h. */
+void SetDeviceRevision(EipUint8 major, EipUint8 minor) {
+  g_identity.revision.major_revision = major;
+  g_identity.revision.minor_revision = minor;
+}
+
+/* The Doxygen comment is with the function's prototype in opener_api.h. */
 void SetDeviceSerialNumber(const EipUint32 serial_number) {
   g_identity.serial_number = serial_number;
 }

--- a/source/src/cip/cipstring.c
+++ b/source/src/cip/cipstring.c
@@ -263,3 +263,24 @@ CipShortString *SetCipShortStringByCstr(CipShortString *const cip_string,
   return SetCipShortStringByData(cip_string, (CipUsint) strlen(string),
                                  (const CipOctet *) string);
 }
+
+/* Ensures buf is NUL terminated, provided initial validation is successful */
+int GetCstrFromCipShortString(CipShortString *const string, char *buf, size_t len) {
+  size_t num;
+  int rc = 0;
+
+  if (!string || !buf || len < 1)
+    return -1;
+
+  num = (size_t)string->length;
+  if (len <= num) {
+    rc = (int)(num - len - 1);
+    num = len - 1;
+  }
+  len = num;
+
+  memcpy(buf, string->string, num);
+  buf[len] = 0;
+
+  return rc;
+}

--- a/source/src/cip/cipstring.h
+++ b/source/src/cip/cipstring.h
@@ -169,4 +169,15 @@ CipShortString *SetCipShortStringByData(CipShortString *const cip_string,
 CipShortString *SetCipShortStringByCstr(CipShortString *const cip_string,
                                         const char *const string);
 
+/** @brief Returns a NUL terminated C-string from a CipShortString
+ *
+ * @param string The CipShortString to extract from
+ * @param buf Pointer to a buffer to store the contents in
+ * @param len Length of buffer
+ *
+ * @return POSIX OK(0) if the complete string fit in @param buf, otherwise non-zero.
+ */
+int GetCstrFromCipShortString(CipShortString *const string, char *buf,
+			      size_t len);
+
 #endif /* of OPENER_CIPSTRING_H_ */

--- a/source/src/enet_encap/encap.c
+++ b/source/src/enet_encap/encap.c
@@ -60,9 +60,6 @@ typedef enum {
 
 #define ENCAP_NUMBER_OF_SUPPORTED_DELAYED_ENCAP_MESSAGES 2 /**< According to EIP spec at least 2 delayed message requests should be supported */
 
-#define ENCAP_MAX_DELAYED_ENCAP_MESSAGE_SIZE ( ENCAPSULATION_HEADER_LENGTH + \
-                                               39 + sizeof(OPENER_DEVICE_NAME) )                             /* currently we only have the size of an encapsulation message */
-
 /* Encapsulation layer data  */
 
 /** @brief Delayed Encapsulation Message structure */

--- a/source/src/opener_api.h
+++ b/source/src/opener_api.h
@@ -137,7 +137,7 @@ CipUint GetDeviceVendorId(void);
  * When OpENer is used as a library, multiple CIP adapters may use it
  * and will need to change the product name.
  */
-void SetDeviceProductName(const CipOctet *product_name);
+void SetDeviceProductName(const char *product_name);
 
 /** @ingroup CIP_API
  * @brief Get device's current CIP ProductName

--- a/source/src/opener_api.h
+++ b/source/src/opener_api.h
@@ -90,6 +90,44 @@ void SetDeviceSerialNumber(const EipUint32 serial_number);
 void SetDeviceStatus(const CipWord status);
 
 /** @ingroup CIP_API
+ * @breif Set device's CIP VendorId
+ *
+ * @param vendor_id vendor ID, can be zero
+ *
+ * When OpENer is used as a library, multiple CIP adapters may use it
+ * and may want to set the VendorId.  Note: some applications allow
+ * the use of VendorId 0.
+ */
+void SetDeviceVendorId(CipUint vendor_id);
+
+/** @ingroup CIP_API
+ * @brief Get device's CIP VendorId
+ *
+ * @returns the currently used VendorId
+ */
+CipUint GetDeviceVendorId(void);
+
+/** @ingroup CIP_API
+ * @breif Set device's CIP ProductName
+ *
+ * @param product_name C-string to use as ProducName
+ *
+ * When OpENer is used as a library, multiple CIP adapters may use it
+ * and will need to change the product name.
+ */
+void SetDeviceProductName(const CipOctet *product_name);
+
+/** @ingroup CIP_API
+ * @brief Get device's current CIP ProductName
+ *
+ * Hint, use GetCstrFromCipShortString() to get a printable/logable C
+ * string, since CipShortString's aren't NUL terminated.
+ *
+ * @returns the CipShortString for the product name
+ */
+CipShortString *GetDeviceProductName(void);
+
+/** @ingroup CIP_API
  * @brief Initialize and setup the CIP-stack
  *
  * @param unique_connection_id value passed to Connection_Manager_Init() to form

--- a/source/src/opener_api.h
+++ b/source/src/opener_api.h
@@ -88,6 +88,20 @@ void SetDeviceRevision(EipUint8 major, EipUint8 minor);
 void SetDeviceSerialNumber(const EipUint32 serial_number);
 
 /** @ingroup CIP_API
+ * @brief Set the DeviceType of the device's identity object.
+ *
+ * @param type 16 bit unsigned number representing the CIP device type
+ */
+void SetDeviceType(const EipUint16 type);
+
+/** @ingroup CIP_API
+ * @brief Set the ProductCode of the device's identity object.
+ *
+ * @param type 16 bit unsigned number representing the product code
+ */
+void SetDeviceProductCode(const EipUint16 code);
+
+/** @ingroup CIP_API
  * @brief Set the device's Status word also updating the Extended Device Status
  *
  * @param status    complete Identity Object's Status word content

--- a/source/src/opener_api.h
+++ b/source/src/opener_api.h
@@ -73,6 +73,14 @@ EipStatus IfaceWaitForIp(const char *const iface,
 void GetHostName(CipString *hostname);
 
 /** @ingroup CIP_API
+ * @brief Set the CIP revision of the device's identity object.
+ *
+ * @param major unsigned 8 bit major revision
+ * @param minor unsigned 8 bit minor revision
+ */
+void SetDeviceRevision(EipUint8 major, EipUint8 minor);
+
+/** @ingroup CIP_API
  * @brief Set the serial number of the device's identity object.
  *
  * @param serial_number unique 32 bit number identifying the device


### PR DESCRIPTION
This patch series adds a set of missing APIs when using OpENer as a library.  The build-time (cmake options) are still honored and used as defaults.

Since OpENer stores strings internally as a byte array + length, not as C strings with a terminating ASCII `NUL`, a helper API for the `CipShortString` has been included as well, named `GetCstrFromCipShortString()`.

New APIs to manage the CIP Identity Object:

  - `SetDeviceRevision()`
  - `SetDeviceType()`
  - `SetDeviceProductCode()`
  - `SetDeviceVendorId()`
  - `GetDeviceVendorId()`
  - `SetDeviceProductName()`
  - `GetDeviceProductName()`

Additionally, an old (unused) macro called `ENCAP_MAX_DELAYED_ENCAP_MESSAGE_SIZE` has been dropped since it referenced the cmake default `OPENER_DEVICE_NAME`.