### PR TITLE
cip: accept the first consumed sequence number unconditionally

### DIFF
--- a/source/src/cip/cipconnectionmanager.c
+++ b/source/src/cip/cipconnectionmanager.c
@@ -298,13 +298,15 @@ EipStatus HandleReceivedConnectedData(const EipUint8 *const data,
 
           if(SEQ_GT32(g_common_packet_format_data_item.address_item.data.
                       sequence_number,
-                      connection_object->eip_level_sequence_count_consuming) ) {
+                      connection_object->eip_level_sequence_count_consuming) ||
+             !connection_object->eip_first_level_sequence_count_received) {
             /* reset the watchdog timer */
             ConnectionObjectResetInactivityWatchdogTimerValue(connection_object);
 
             /* only inform assembly object if the sequence counter is greater or equal */
             connection_object->eip_level_sequence_count_consuming =
               g_common_packet_format_data_item.address_item.data.sequence_number;
+            connection_object->eip_first_level_sequence_count_received = true;
 
             if(NULL != connection_object->connection_receive_data_function) {
               return connection_object->connection_receive_data_function(

--- a/source/src/cip/cipconnectionobject.c
+++ b/source/src/cip/cipconnectionobject.c
@@ -905,6 +905,7 @@ void ConnectionObjectResetSequenceCounts(
   connection_object->eip_level_sequence_count_producing = 0;
   connection_object->sequence_count_producing = 0;
   connection_object->eip_level_sequence_count_consuming = 0;
+  connection_object->eip_first_level_sequence_count_received = false;
   connection_object->sequence_count_consuming = 0;
 }
 

--- a/source/src/cip/cipconnectionobject.h
+++ b/source/src/cip/cipconnectionobject.h
@@ -167,7 +167,9 @@ struct cip_connection_object {
                                                    Producing Connections may have a
                                                    different
                                                    value than SequenceCountProducing */
-
+  CipBool eip_first_level_sequence_count_received; /**< False if eip_level_sequence_count_consuming
+                                                   hasn't been initialized with a sequence
+                                                   count yet, true otherwise */
   CipInt correct_originator_to_target_size;
   CipInt correct_target_to_originator_size;
 


### PR DESCRIPTION
Accept the first consumed sequence number without comparing it to 0.

ODVA CT18.1 will send sequence numbers that starts at 0x80000000, which
will not pass SEQ_GT32 when compared to 0.

This commit adds a boolean flag to the cip_connection_object that
indicates if the eip_level_sequence_count_consuming counter was
initialized with data from the client.

Signed-off-by: Charles Perry <charles.perry@savoirfairelinux.com>