### PR TITLE
Seed PRNG before calling rand()

### DIFF
--- a/source/src/ports/MINGW/main.c
+++ b/source/src/ports/MINGW/main.c
@@ -6,6 +6,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <signal.h>
+#include <time.h>
 
 #include "generic_networkhandler.h"
 #include "opener_api.h"
@@ -74,8 +75,11 @@ int main(int argc,
   SetDeviceSerialNumber(123456789);
 
   /* unique_connection_id should be sufficiently random or incremented and stored
-   *  in non-volatile memory each time the device boots.
+   *  in non-volatile memory each time the device boots. This is used as the upper
+   *  16 bits of the connection id. Here we use random number approach, first seed
+   *  the PRNG to ensure we don't get the same value on every startup.
    */
+  srand(time(NULL));
   EipUint16 unique_connection_id = rand();
 
   /* Setup the CIP Layer. All objects are initialized with the default

--- a/source/src/ports/POSIX/main.c
+++ b/source/src/ports/POSIX/main.c
@@ -6,6 +6,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <signal.h>
+#include <time.h>
 #include <unistd.h>
 #include <sys/capability.h>
 
@@ -117,8 +118,11 @@ int main(int argc,
   SetDeviceSerialNumber(123456789);
 
   /* unique_connection_id should be sufficiently random or incremented and stored
-   *  in non-volatile memory each time the device boots.
+   *  in non-volatile memory each time the device boots. This is used as the upper
+   *  16 bits of the connection id. Here we use random number approach, first seed
+   *  the PRNG to ensure we don't get the same value on every startup.
    */
+  srand(time(NULL));
   EipUint16 unique_connection_id = rand();
 
   /* Setup the CIP Layer. All objects are initialized with the default

--- a/source/src/ports/WIN32/main.c
+++ b/source/src/ports/WIN32/main.c
@@ -6,6 +6,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <signal.h>
+#include <time.h>
 
 #include "generic_networkhandler.h"
 #include "opener_api.h"
@@ -73,8 +74,11 @@ int main(int argc, char *arg[]) {
 	SetDeviceSerialNumber(123456789);
 
 	/* unique_connection_id should be sufficiently random or incremented and stored
-	*  in non-volatile memory each time the device boots.
+	*  in non-volatile memory each time the device boots. This is used as the upper
+	*  16 bits of the connection id. Here we use random number approach, first seed
+	*  the PRNG to ensure we don't get the same value on every startup.
 	*/
+	srand(time(NULL));
 	EipUint16 unique_connection_id = rand();
 
 	/* Setup the CIP Layer. All objects are initialized with the default


### PR DESCRIPTION
I got a bit of an odd feedback from my customer; "the connection ids are strangely consecutive ...".  After a bit of testing to try and understand what they meant, it slowly dawned on me that they meant between reboots.  

Sure enough, with their report next to me listing the connection ids they had from our adapter in production, I ran the same adapter version on my PC just to notice the exact same upper 16 bits of the connection id .. 0x4567!

Like many others, I suspect, we've built our adapter using the sample application.  So I thought it might be a good idea to share my "fix".  I've only tested it on Linux with GLIBC's `rand()` implementation, and calling `srand()` with the output from `time()` helps a lot.

Mingw should work the same as POSIX, and after a bit of googling it seems Win32 also supports these same APIs.  Still, it's best considering this PR as an RFC.
