### PR TITLE
[RFC PATCH]: Transfer CIP I/O connections on both timeout and close

### DIFF
--- a/source/src/cip/cipioconnection.c
+++ b/source/src/cip/cipioconnection.c
@@ -985,15 +985,13 @@ CipError OpenCommunicationChannels(CipConnectionObject *connection_object) {
 
 void CloseCommunicationChannelsAndRemoveFromActiveConnectionsList(
   CipConnectionObject *connection_object) {
-  CloseUdpSocket(connection_object->socket[kUdpCommuncationDirectionConsuming]);
+  if(kEipInvalidSocket !=
+      connection_object->socket[kUdpCommuncationDirectionConsuming])
+    CloseUdpSocket(connection_object->socket[kUdpCommuncationDirectionConsuming]);
 
-  connection_object->socket[kUdpCommuncationDirectionConsuming] =
-    kEipInvalidSocket;
-
-  CloseUdpSocket(connection_object->socket[kUdpCommuncationDirectionProducing]);
-
-  connection_object->socket[kUdpCommuncationDirectionProducing] =
-    kEipInvalidSocket;
+  if(kEipInvalidSocket !=
+      connection_object->socket[kUdpCommuncationDirectionProducing])
+    CloseUdpSocket(connection_object->socket[kUdpCommuncationDirectionProducing]);
 
   RemoveFromActiveConnections(connection_object);
   ConnectionObjectInitializeEmpty(connection_object);

--- a/source/src/cip/cipioconnection.c
+++ b/source/src/cip/cipioconnection.c
@@ -526,15 +526,13 @@ EipStatus OpenProducingMulticastConnection(
       kEipInvalidSocket;
   }
 
-  common_packet_format_data->address_info_item[j].length = 16;
+  memcpy(&connection_object->remote_address, &existing_connection_object->remote_address, sizeof(connection_object->remote_address));
+  connection_object->eip_level_sequence_count_producing = existing_connection_object->eip_level_sequence_count_producing;
+  connection_object->sequence_count_producing = existing_connection_object->sequence_count_producing;
+  connection_object->transmission_trigger_timer = existing_connection_object->transmission_trigger_timer;
 
-  connection_object->remote_address.sin_family = AF_INET;
-  connection_object->remote_address.sin_port =
-    common_packet_format_data->address_info_item[j].sin_port = port;
-  connection_object->remote_address.sin_addr.s_addr =
-    common_packet_format_data->address_info_item[j].sin_addr =
-      g_tcpip.mcast_config.starting_multicast_address;
   memset(common_packet_format_data->address_info_item[j].nasin_zero, 0, 8);
+  common_packet_format_data->address_info_item[j].length = 16;
   common_packet_format_data->address_info_item[j].sin_family = htons(AF_INET);
 
   return kEipStatusOk;

--- a/source/src/ports/generic_networkhandler.c
+++ b/source/src/ports/generic_networkhandler.c
@@ -349,10 +349,12 @@ EipStatus NetworkHandlerInitialize(void) {
 }
 
 void CloseUdpSocket(int socket_handle) {
+  OPENER_TRACE_STATE("Closing UDP socket %d\n", socket_handle);
   CloseSocket(socket_handle);
 }
 
 void CloseTcpSocket(int socket_handle) {
+  OPENER_TRACE_STATE("Closing TCP socket %d\n", socket_handle);
   ShutdownSocketPlatform(socket_handle);
   RemoveSocketTimerFromList(socket_handle);
   CloseSocket(socket_handle);

--- a/source/src/ports/generic_networkhandler.c
+++ b/source/src/ports/generic_networkhandler.c
@@ -711,14 +711,7 @@ EipStatus HandleDataOnTcpSocket(int socket) {
                                                              OPENER_NUMBER_OF_SUPPORTED_SESSIONS,
                                                              socket);
   if(number_of_read_bytes == 0) {
-    int error_code = GetSocketErrorNumber();
-    char *error_message = GetErrorMessage(error_code);
-    OPENER_TRACE_ERR(
-      "networkhandler: socket: %d - connection closed by client: %d - %s\n",
-      socket,
-      error_code,
-      error_message);
-    FreeErrorMessage(error_message);
+    OPENER_TRACE_ERR("networkhandler: socket: %d - connection closed by client.\n", socket);
     RemoveSocketTimerFromList(socket);
     RemoveSession(socket);
     return kEipStatusError;


### PR DESCRIPTION
This RFC change set is an attempt at fixing issues described in #393. 

Each respective patch fixes a single problem at a time.  The introduction of the factored-out helper function `transfer_master_connection()` is the only really hairy piece of code, and the one mandating the RFC status of this change set.

Some other minor fixes, and code cleanups for readability, are included as well.
