### PR TITLE
Add support for random connection IDs also for lower 16-bits

### DIFF
--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -34,10 +34,15 @@ find_path( OpENer_BUILDSUPPORT_DIR OpENer.cmake ${PROJECT_SOURCE_DIR}/buildsuppo
 
 INCLUDE( ${OpENer_BUILDSUPPORT_DIR}/OpENer.cmake )
 
+option(OPENER_RANDOMIZE_CONNECTION_ID "Use randomized connection IDs also for lower 16-bits?" FALSE)
 option(OPENER_PRODUCED_DATA_HAS_RUN_IDLE_HEADER "Shall produced data from OpENer also include a run idle header?" FALSE)
 option(OPENER_CONSUMED_DATA_HAS_RUN_IDLE_HEADER "Will consumed data from OpENer also include a run idle header?" TRUE)
 option(OPENER_INSTALL_AS_LIB "Build and install OpENer as a library" FALSE)
 option(BUILD_SHARED_LIBS "Build OpENer as shared library" FALSE)
+
+if(OPENER_RANDOMIZE_CONNECTION_ID)
+  add_definitions(-DOPENER_RANDOMIZE_CONNECTION_ID)
+endif()
 
 if(OPENER_PRODUCED_DATA_HAS_RUN_IDLE_HEADER)
   add_definitions(-DOPENER_PRODUCED_DATA_HAS_RUN_IDLE_HEADER)

--- a/source/src/utils/xorshiftrandom.c
+++ b/source/src/utils/xorshiftrandom.c
@@ -4,6 +4,7 @@
  *
  ******************************************************************************/
 
+#include <time.h>
 #include "xorshiftrandom.h"
 
 static uint32_t xor_shift_seed; /** < File-global variable holding the current seed*/
@@ -17,6 +18,9 @@ void SetXorShiftSeed(uint32_t seed) {
  * Works directly on the file global variable
  */
 void CalculateNextSeed(void) {
+  if (xor_shift_seed == 0)
+    SetXorShiftSeed(time(NULL));
+
   xor_shift_seed ^= xor_shift_seed << 13;
   xor_shift_seed ^= xor_shift_seed >> 17;
   xor_shift_seed ^= xor_shift_seed << 5;


### PR DESCRIPTION
As mentioned in PR #392, some conformance tests may fail an adapter that uses semi-sequential connection IDs.  This patch adds optional support for enabling fully random IDs, where the upper 16-bits are still taken from the per-session incarnation ID and the lower 16-bits are now random from the xor-shift implementation.

Included is an initial seeding using `time(NULL)` if the `SetXorShiftSeed()` function has not been called by the application.