### PR TITLE
Fix return type conversion

### DIFF
--- a/source/src/opener_api.h
+++ b/source/src/opener_api.h
@@ -612,7 +612,7 @@ typedef EipStatus (*ConnectionSendDataFunction)(CipConnectionObject *
  *
  * @return Stack status
  */
-typedef CipError (*ConnectionReceiveDataFunction)(CipConnectionObject *
+typedef EipStatus (*ConnectionReceiveDataFunction)(CipConnectionObject *
                                                   connection_object,
                                                   const EipUint8 *data,
                                                   const EipUint16 data_length);


### PR DESCRIPTION
[Sonar] Fixes implicit return type conversion for connection_receive_data_function

Signed-off-by: Martin Melik-Merkumians <melik-merkumians@acin.tuwien.ac.at>
