### PR TITLE
Fix calloc parameter types

### DIFF
--- a/source/src/ports/WIN32/sample_application/sampleapplication.c
+++ b/source/src/ports/WIN32/sample_application/sampleapplication.c
@@ -186,8 +186,8 @@ EipStatus ResetDeviceToInitialConfiguration(void) {
 }
 
 void *
-CipCalloc(unsigned pa_nNumberOfElements,
-          unsigned pa_nSizeOfElement) {
+CipCalloc(size_t pa_nNumberOfElements,
+          size_t pa_nSizeOfElement) {
   return calloc(pa_nNumberOfElements, pa_nSizeOfElement);
 }
 


### PR DESCRIPTION
Please test this on a x64 Windows platform. I currently only have 32-bit Windows hosts, which do not generate warnings about these parameters, likely because unsigned is the same size as size_t. This should resolve warnings on 64-bit systems.