### PR TITLE
Issue #445 - Fix vulnerability on multiple encap layer requests in one message

### DIFF
--- a/source/src/cip/cipioconnection.c
+++ b/source/src/cip/cipioconnection.c
@@ -79,33 +79,30 @@ static EipUint8 s_produce_run_idle = 1;
 static EipUint8 s_produce_run_idle = 0;
 #endif
 
-void CipRunIdleHeaderSetO2T(bool onoff)
-{
+void CipRunIdleHeaderSetO2T(bool onoff) {
   s_consume_run_idle = onoff;
 }
 
-bool CipRunIdleHeaderGetO2T(void)
-{
+bool CipRunIdleHeaderGetO2T(void) {
   return s_consume_run_idle;
 }
 
-void CipRunIdleHeaderSetT2O(bool onoff)
-{
+void CipRunIdleHeaderSetT2O(bool onoff) {
   s_produce_run_idle = onoff;
 }
 
-bool CipRunIdleHeaderGetT2O(void)
-{
+bool CipRunIdleHeaderGetT2O(void) {
   return s_produce_run_idle;
 }
 
-EipUint16 ProcessProductionInhibitTime(CipConnectionObject *io_connection_object)
-{
-  if(kConnectionObjectTransportClassTriggerProductionTriggerCyclic ==
-     ConnectionObjectGetTransportClassTriggerProductionTrigger(
-       io_connection_object) )
+EipUint16 ProcessProductionInhibitTime(
+  CipConnectionObject *io_connection_object) {
+  if( kConnectionObjectTransportClassTriggerProductionTriggerCyclic ==
+      ConnectionObjectGetTransportClassTriggerProductionTrigger(
+        io_connection_object) )
   {
-    if(256 == ConnectionObjectGetProductionInhibitTime(io_connection_object) ) {
+    if( 256 ==
+        ConnectionObjectGetProductionInhibitTime(io_connection_object) ) {
       OPENER_TRACE_INFO("No PIT segment available\n");
       /* there was no PIT segment in the connection path; set PIT to one fourth of RPI */
       ConnectionObjectSetProductionInhibitTime(io_connection_object,
@@ -113,9 +110,10 @@ EipUint16 ProcessProductionInhibitTime(CipConnectionObject *io_connection_object
                                                  io_connection_object) / 4000);
     } else {
       /* If a production inhibit time is provided, it needs to be smaller than the Requested Packet Interval */
-      if(ConnectionObjectGetProductionInhibitTime(io_connection_object) >
-         (ConnectionObjectGetTToORequestedPacketInterval(io_connection_object) /
-          1000) ) {
+      if( ConnectionObjectGetProductionInhibitTime(io_connection_object) >
+          (ConnectionObjectGetTToORequestedPacketInterval(io_connection_object)
+           /
+           1000) ) {
         /* see section C-1.4.3.3 */
         return
           kConnectionManagerExtendedStatusCodeProductionInhibitTimerGreaterThanRpi;
@@ -139,9 +137,9 @@ EipUint16 SetupIoConnectionOriginatorToTargetConnectionPoint(
   CipClass *const assembly_class = GetCipClass(kCipAssemblyClassCode);
   CipInstance *instance = NULL;
   if( NULL !=
-      (instance =
-         GetCipInstance(assembly_class,
-                        io_connection_object->consumed_path.instance_id) ) ) {
+      ( instance =
+          GetCipInstance(assembly_class,
+                         io_connection_object->consumed_path.instance_id) ) ) {
     /* consuming Connection Point is present */
     io_connection_object->consuming_instance = instance;
     io_connection_object->consumed_connection_path_length = 6;
@@ -160,9 +158,9 @@ EipUint16 SetupIoConnectionOriginatorToTargetConnectionPoint(
                                                     kAssemblyObjectInstanceAttributeIdData);
     OPENER_ASSERT(attribute != NULL);
     bool is_heartbeat = ( ( (CipByteArray *) attribute->data )->length == 0 );
-    if(kConnectionObjectTransportClassTriggerTransportClass1 ==
-       ConnectionObjectGetTransportClassTriggerTransportClass(
-         io_connection_object) )
+    if( kConnectionObjectTransportClassTriggerTransportClass1 ==
+        ConnectionObjectGetTransportClassTriggerTransportClass(
+          io_connection_object) )
     {
       /* class 1 connection */
       data_size -= 2; /* remove 16-bit sequence count length */
@@ -191,44 +189,45 @@ EipUint16 SetupIoConnectionTargetToOriginatorConnectionPoint(
   CipConnectionObject *const io_connection_object,
   CipConnectionObject *const RESTRICT connection_object) {
   DoublyLinkedListNode *node = connection_list.first;
-  while(NULL != node &&
-        kConnectionObjectConnectionTypeMulticast ==
-        ConnectionObjectGetTToOConnectionType(io_connection_object) ) {
+  while( NULL != node &&
+         kConnectionObjectConnectionTypeMulticast ==
+         ConnectionObjectGetTToOConnectionType(io_connection_object) ) {
     CipConnectionObject *iterator = node->data;
     if(io_connection_object->produced_path.instance_id ==
        iterator->produced_path.instance_id) {
       //Check parameters
-      if(ConnectionObjectGetTToORequestedPacketInterval(io_connection_object) !=
-         ConnectionObjectGetTToORequestedPacketInterval(iterator) ) {
+      if( ConnectionObjectGetTToORequestedPacketInterval(io_connection_object)
+          !=
+          ConnectionObjectGetTToORequestedPacketInterval(iterator) ) {
         return kConnectionManagerExtendedStatusCodeErrorRpiValuesNotAcceptable;
       }
-      if(ConnectionObjectGetTToOConnectionSizeType(io_connection_object) !=
-         ConnectionObjectGetTToOConnectionSizeType(iterator) ) {
+      if( ConnectionObjectGetTToOConnectionSizeType(io_connection_object) !=
+          ConnectionObjectGetTToOConnectionSizeType(iterator) ) {
         return
           kConnectionManagerExtendedStatusCodeMismatchedTToONetworkConnectionFixVar;
       }
-      if(ConnectionObjectGetTToOPriority(io_connection_object) !=
-         ConnectionObjectGetTToOPriority(iterator) ) {
+      if( ConnectionObjectGetTToOPriority(io_connection_object) !=
+          ConnectionObjectGetTToOPriority(iterator) ) {
         return
           kConnectionManagerExtendedStatusCodeMismatchedTToONetworkConnectionPriority;
       }
 
-      if(ConnectionObjectGetTransportClassTriggerTransportClass(
-           io_connection_object) !=
-         ConnectionObjectGetTransportClassTriggerTransportClass(iterator) ) {
+      if( ConnectionObjectGetTransportClassTriggerTransportClass(
+            io_connection_object) !=
+          ConnectionObjectGetTransportClassTriggerTransportClass(iterator) ) {
         return kConnectionManagerExtendedStatusCodeMismatchedTransportClass;
       }
 
-      if(ConnectionObjectGetTransportClassTriggerProductionTrigger(
-           io_connection_object)
-         != ConnectionObjectGetTransportClassTriggerProductionTrigger(iterator) )
+      if( ConnectionObjectGetTransportClassTriggerProductionTrigger(
+            io_connection_object)
+          != ConnectionObjectGetTransportClassTriggerProductionTrigger(iterator) )
       {
         return
           kConnectionManagerExtendedStatusCodeMismatchedTToOProductionTrigger;
       }
 
-      if(ConnectionObjectGetProductionInhibitTime(io_connection_object) !=
-         ConnectionObjectGetProductionInhibitTime(iterator) ) {
+      if( ConnectionObjectGetProductionInhibitTime(io_connection_object) !=
+          ConnectionObjectGetProductionInhibitTime(iterator) ) {
         return
           kConnectionManagerExtendedStatusCodeMismatchedTToOProductionInhibitTimeSegment;
       }
@@ -242,9 +241,9 @@ EipUint16 SetupIoConnectionTargetToOriginatorConnectionPoint(
   CipClass *const assembly_class = GetCipClass(kCipAssemblyClassCode);
   CipInstance *instance = NULL;
   if( NULL !=
-      (instance =
-         GetCipInstance(assembly_class,
-                        io_connection_object->produced_path.instance_id) ) ) {
+      ( instance =
+          GetCipInstance(assembly_class,
+                         io_connection_object->produced_path.instance_id) ) ) {
 
     io_connection_object->producing_instance = instance;
     int data_size = ConnectionObjectGetTToOConnectionSize(io_connection_object);
@@ -256,9 +255,9 @@ EipUint16 SetupIoConnectionTargetToOriginatorConnectionPoint(
                                                     kAssemblyObjectInstanceAttributeIdData);
     OPENER_ASSERT(attribute != NULL);
     bool is_heartbeat = ( ( (CipByteArray *) attribute->data )->length == 0 );
-    if(kConnectionObjectTransportClassTriggerTransportClass1 ==
-       ConnectionObjectGetTransportClassTriggerTransportClass(
-         io_connection_object) )
+    if( kConnectionObjectTransportClassTriggerTransportClass1 ==
+        ConnectionObjectGetTransportClassTriggerTransportClass(
+          io_connection_object) )
     {
       /* class 1 connection */
       data_size -= 2; /* remove 16-bit sequence count length */
@@ -373,18 +372,17 @@ CipError EstablishIoConnection(
   return cip_error;
 }
 
-static SocketAddressInfoItem* AllocateSocketAddressInfoItem(
+static SocketAddressInfoItem *AllocateSocketAddressInfoItem(
   CipCommonPacketFormatData *const common_packet_format_data,
-  CipUint type)
-{
+  CipUint type) {
   const int address_info_item_size =
     sizeof(common_packet_format_data->address_info_item) /
-      sizeof(common_packet_format_data->address_info_item[0]);
+    sizeof(common_packet_format_data->address_info_item[0]);
 
-  SocketAddressInfoItem* s = common_packet_format_data->address_info_item;
+  SocketAddressInfoItem *s = common_packet_format_data->address_info_item;
 
   for (int i = 0; i < address_info_item_size; i++) {
-    if((s->type_id == 0) || (s->type_id == type)) {
+    if( (s->type_id == 0) || (s->type_id == type) ) {
       return s;
     }
     s++;
@@ -403,7 +401,7 @@ EipStatus OpenConsumingPointToPointConnection(
   CipConnectionObject *const connection_object,
   CipCommonPacketFormatData *const common_packet_format_data) {
 
-  SocketAddressInfoItem* sock_addr_info =
+  SocketAddressInfoItem *sock_addr_info =
     AllocateSocketAddressInfoItem(common_packet_format_data,
                                   kCipItemIdSocketAddressInfoOriginatorToTarget);
 
@@ -429,8 +427,8 @@ EipStatus OpenConsumingPointToPointConnection(
   connection_object->originator_address.sin_addr.s_addr = GetPeerAddress();
   connection_object->originator_address.sin_port = htons(kOpenerEipIoUdpPort);
 
-  connection_object->socket[kUdpCommuncationDirectionConsuming] = 
-      g_network_status.udp_io_messaging;
+  connection_object->socket[kUdpCommuncationDirectionConsuming] =
+    g_network_status.udp_io_messaging;
 
   sock_addr_info->length = 16;
   sock_addr_info->type_id = kCipItemIdSocketAddressInfoOriginatorToTarget;
@@ -445,10 +443,9 @@ EipStatus OpenConsumingPointToPointConnection(
 
 CipError OpenProducingPointToPointConnection(
   CipConnectionObject *connection_object,
-  CipCommonPacketFormatData *common_packet_format_data)
-{
+  CipCommonPacketFormatData *common_packet_format_data) {
   /* the default port to be used if no port information is part of the forward open request */
-  in_port_t port = htons(kOpenerEipIoUdpPort); 
+  in_port_t port = htons(kOpenerEipIoUdpPort);
 
   if(kCipItemIdSocketAddressInfoTargetToOriginator ==
      common_packet_format_data->address_info_item[0].type_id) {
@@ -461,33 +458,32 @@ CipError OpenProducingPointToPointConnection(
   }
 
   connection_object->remote_address.sin_family = AF_INET;
-  connection_object->remote_address.sin_addr.s_addr = GetPeerAddress(); 
+  connection_object->remote_address.sin_addr.s_addr = GetPeerAddress();
   connection_object->remote_address.sin_port = port;
 
   CipUsint qos_for_socket = ConnectionObjectGetTToOPriority(connection_object);
   int error = SetQos(qos_for_socket);
   if (error != 0) {
     OPENER_TRACE_ERR(
-        "cannot set QoS for UDP socket in OpenPointToPointConnection\n");
+      "cannot set QoS for UDP socket in OpenPointToPointConnection\n");
     return kEipStatusError;
   }
 
   connection_object->socket[kUdpCommuncationDirectionProducing] =
-      g_network_status.udp_io_messaging;
+    g_network_status.udp_io_messaging;
 
   return kCipErrorSuccess;
 }
 
 EipStatus OpenProducingMulticastConnection(
   CipConnectionObject *connection_object,
-  CipCommonPacketFormatData *common_packet_format_data)
-{
+  CipCommonPacketFormatData *common_packet_format_data) {
   /* Here we look for existing multi-cast IO connections only. */
   CipConnectionObject *existing_connection_object =
     GetExistingProducerIoConnection(true,
                                     connection_object->produced_path.instance_id);
 
-  SocketAddressInfoItem* sock_addr_info =
+  SocketAddressInfoItem *sock_addr_info =
     AllocateSocketAddressInfoItem(common_packet_format_data,
                                   kCipItemIdSocketAddressInfoTargetToOriginator);
 
@@ -535,7 +531,7 @@ EipStatus OpenProducingMulticastConnection(
   connection_object->remote_address.sin_family = AF_INET;
   connection_object->remote_address.sin_port = sock_addr_info->sin_port = port;
   connection_object->remote_address.sin_addr.s_addr = sock_addr_info->sin_addr =
-      g_tcpip.mcast_config.starting_multicast_address;
+    g_tcpip.mcast_config.starting_multicast_address;
   memset(sock_addr_info->nasin_zero, 0, 8);
   sock_addr_info->sin_family = htons(AF_INET);
 
@@ -602,7 +598,8 @@ EipStatus OpenMulticastConnection(UdpCommuncationDirection direction,
      common_packet_format_data->address_info_item[j].type_id) {
     /* we are using an unused item initialize it with the default multicast address */
     common_packet_format_data->address_info_item[j].sin_family = htons(AF_INET);
-    common_packet_format_data->address_info_item[j].sin_port = htons(kOpenerEipIoUdpPort);
+    common_packet_format_data->address_info_item[j].sin_port = htons(
+      kOpenerEipIoUdpPort);
     common_packet_format_data->address_info_item[j].sin_addr =
       g_tcpip.mcast_config.starting_multicast_address;
     memset(common_packet_format_data->address_info_item[j].nasin_zero, 0, 8);
@@ -629,7 +626,7 @@ EipStatus OpenMulticastConnection(UdpCommuncationDirection direction,
   int error = SetQos(qos_for_socket);
   if (error != 0) {
     OPENER_TRACE_ERR(
-        "cannot set QoS for UDP socket in OpenMulticastConnection\n");
+      "cannot set QoS for UDP socket in OpenMulticastConnection\n");
     return kEipStatusError;
   }
   if (direction == kUdpCommuncationDirectionProducing) {
@@ -662,8 +659,9 @@ EipUint16 HandleConfigData(CipConnectionObject *connection_object) {
 
   if(0 != g_config_data_length) {
     OPENER_ASSERT(NULL != config_instance);
-    if(ConnectionWithSameConfigPointExists(connection_object->configuration_path
-                                           .instance_id) ) {
+    if( ConnectionWithSameConfigPointExists(connection_object->
+                                            configuration_path
+                                            .instance_id) ) {
       /* there is a connected connection with the same config point
        * we have to have the same data as already present in the config point*/
       CipAttributeStruct *attribute_three = GetCipAttribute(config_instance, 3);
@@ -678,8 +676,8 @@ EipUint16 HandleConfigData(CipConnectionObject *connection_object) {
           "Hit an Ownership conflict in cipioconnection.c occurrence 1");
       } else {
         /*FIXME check if this is correct */
-        if(memcmp(attribute_three_data->data, g_config_data_buffer,
-                  g_config_data_length) ) {
+        if( memcmp(attribute_three_data->data, g_config_data_buffer,
+                   g_config_data_length) ) {
           connection_manager_status =
             kConnectionManagerExtendedStatusCodeErrorOwnershipConflict;
           OPENER_TRACE_INFO(
@@ -689,10 +687,10 @@ EipUint16 HandleConfigData(CipConnectionObject *connection_object) {
     } else {
       /* put the data on the configuration assembly object with the current
          design this can be done rather efficiently */
-      if(kEipStatusOk !=
-         NotifyAssemblyConnectedDataReceived(config_instance,
-                                             g_config_data_buffer,
-                                             g_config_data_length) ) {
+      if( kEipStatusOk !=
+          NotifyAssemblyConnectedDataReceived(config_instance,
+                                              g_config_data_buffer,
+                                              g_config_data_length) ) {
         OPENER_TRACE_WARN("Configuration data was invalid\n");
         connection_manager_status =
           kConnectionManagerExtendedStatusCodeInvalidConfigurationApplicationPath;
@@ -709,43 +707,58 @@ EipUint16 HandleConfigData(CipConnectionObject *connection_object) {
 static int transfer_master_connection(CipConnectionObject *connection_object) {
   CipConnectionObject *active;
 
-  active = GetNextNonControlMasterConnection(connection_object->produced_path.instance_id);
-  if (!active)
+  active = GetNextNonControlMasterConnection(
+    connection_object->produced_path.instance_id);
+  if (!active) {
     return 1;
+  }
 
   OPENER_TRACE_INFO("Transferring socket ownership\n");
-  active->socket[kUdpCommuncationDirectionProducing] = connection_object->socket[kUdpCommuncationDirectionProducing];
-  connection_object->socket[kUdpCommuncationDirectionProducing] = kEipInvalidSocket;
+  active->socket[kUdpCommuncationDirectionProducing] =
+    connection_object->socket[kUdpCommuncationDirectionProducing];
+  connection_object->socket[kUdpCommuncationDirectionProducing] =
+    kEipInvalidSocket;
 
-  memcpy(&(active->remote_address), &(connection_object->remote_address), sizeof(active->remote_address));
-  active->eip_level_sequence_count_producing = connection_object->eip_level_sequence_count_producing;
-  active->sequence_count_producing = connection_object->sequence_count_producing;
-  active->transmission_trigger_timer = connection_object->transmission_trigger_timer;
+  memcpy( &(active->remote_address), &(connection_object->remote_address),
+          sizeof(active->remote_address) );
+  active->eip_level_sequence_count_producing =
+    connection_object->eip_level_sequence_count_producing;
+  active->sequence_count_producing =
+    connection_object->sequence_count_producing;
+  active->transmission_trigger_timer =
+    connection_object->transmission_trigger_timer;
 
   return 0;
 }
 
 /* Always sync any changes with HandleIoConnectionTimeout() */
 void CloseIoConnection(CipConnectionObject *RESTRICT connection_object) {
-  ConnectionObjectInstanceType instance_type = ConnectionObjectGetInstanceType(connection_object);
-  ConnectionObjectConnectionType conn_type = ConnectionObjectGetTToOConnectionType(connection_object);
+  ConnectionObjectInstanceType instance_type = ConnectionObjectGetInstanceType(
+    connection_object);
+  ConnectionObjectConnectionType conn_type =
+    ConnectionObjectGetTToOConnectionType(connection_object);
 
   CheckIoConnectionEvent(connection_object->consumed_path.instance_id,
                          connection_object->produced_path.instance_id,
                          kIoConnectionEventClosed);
-  ConnectionObjectSetState(connection_object, kConnectionObjectStateNonExistent);
+  ConnectionObjectSetState(connection_object,
+                           kConnectionObjectStateNonExistent);
 
   if(kConnectionObjectInstanceTypeIOExclusiveOwner == instance_type ||
      kConnectionObjectInstanceTypeIOInputOnly == instance_type) {
     if(kConnectionObjectConnectionTypeMulticast == conn_type &&
-       kEipInvalidSocket != connection_object->socket[kUdpCommuncationDirectionProducing]) {
-      OPENER_TRACE_INFO("Exclusive Owner or Input Only connection closed - Instance type: %d\n", instance_type);
+       kEipInvalidSocket !=
+       connection_object->socket[kUdpCommuncationDirectionProducing]) {
+      OPENER_TRACE_INFO(
+        "Exclusive Owner or Input Only connection closed - Instance type: %d\n",
+        instance_type);
 
-      if(transfer_master_connection(connection_object)) {
+      if( transfer_master_connection(connection_object) ) {
         /* No transfer, this was the last master connection, close all
          * listen only connections listening on the port */
-        CloseAllConnectionsForInputWithSameType(connection_object->produced_path.instance_id,
-                                                kConnectionObjectInstanceTypeIOListenOnly);
+        CloseAllConnectionsForInputWithSameType(
+          connection_object->produced_path.instance_id,
+          kConnectionObjectInstanceTypeIOListenOnly);
       }
     }
   }
@@ -755,8 +768,10 @@ void CloseIoConnection(CipConnectionObject *RESTRICT connection_object) {
 
 /* Always sync any changes with CloseIoConnection() */
 void HandleIoConnectionTimeOut(CipConnectionObject *connection_object) {
-  ConnectionObjectInstanceType instance_type = ConnectionObjectGetInstanceType(connection_object);
-  ConnectionObjectConnectionType conn_type = ConnectionObjectGetTToOConnectionType(connection_object);
+  ConnectionObjectInstanceType instance_type = ConnectionObjectGetInstanceType(
+    connection_object);
+  ConnectionObjectConnectionType conn_type =
+    ConnectionObjectGetTToOConnectionType(connection_object);
   int handover = 0;
 
   CheckIoConnectionEvent(connection_object->consumed_path.instance_id,
@@ -764,33 +779,42 @@ void HandleIoConnectionTimeOut(CipConnectionObject *connection_object) {
                          kIoConnectionEventTimedOut);
   ConnectionObjectSetState(connection_object, kConnectionObjectStateTimedOut);
 
-  if(connection_object->last_package_watchdog_timer == connection_object->inactivity_watchdog_timer)
+  if(connection_object->last_package_watchdog_timer ==
+     connection_object->inactivity_watchdog_timer) {
     CheckForTimedOutConnectionsAndCloseTCPConnections(connection_object,
                                                       CloseEncapsulationSessionBySockAddr);
+  }
 
   if(kConnectionObjectInstanceTypeIOExclusiveOwner == instance_type ||
      kConnectionObjectInstanceTypeIOInputOnly == instance_type) {
     if(kConnectionObjectConnectionTypeMulticast == conn_type &&
-       kEipInvalidSocket != connection_object->socket[kUdpCommuncationDirectionProducing]) {
-      OPENER_TRACE_INFO("Exclusive Owner or Input Only connection timed out - Instance type: %d\n", instance_type);
+       kEipInvalidSocket !=
+       connection_object->socket[kUdpCommuncationDirectionProducing]) {
+      OPENER_TRACE_INFO(
+        "Exclusive Owner or Input Only connection timed out - Instance type: %d\n",
+        instance_type);
       /* we are the controlling input only connection find a new controller*/
 
-      if(transfer_master_connection(connection_object)) {
+      if( transfer_master_connection(connection_object) ) {
         /* No transfer, this was the last master connection, close all
          * listen only connections listening on the port */
-        CloseAllConnectionsForInputWithSameType(connection_object->produced_path.instance_id,
-                                                kConnectionObjectInstanceTypeIOListenOnly);
+        CloseAllConnectionsForInputWithSameType(
+          connection_object->produced_path.instance_id,
+          kConnectionObjectInstanceTypeIOListenOnly);
       } else {
-	handover = 1;
+        handover = 1;
       }
     }
   }
 
-  if(kConnectionObjectInstanceTypeIOExclusiveOwner == instance_type && !handover) {
-    CloseAllConnectionsForInputWithSameType(connection_object->produced_path.instance_id,
-                                            kConnectionObjectInstanceTypeIOInputOnly);
-    CloseAllConnectionsForInputWithSameType(connection_object->produced_path.instance_id,
-                                            kConnectionObjectInstanceTypeIOListenOnly);
+  if(kConnectionObjectInstanceTypeIOExclusiveOwner == instance_type &&
+     !handover) {
+    CloseAllConnectionsForInputWithSameType(
+      connection_object->produced_path.instance_id,
+      kConnectionObjectInstanceTypeIOInputOnly);
+    CloseAllConnectionsForInputWithSameType(
+      connection_object->produced_path.instance_id,
+      kConnectionObjectInstanceTypeIOListenOnly);
   }
 
   ConnectionObjectSetState(connection_object, kConnectionObjectStateTimedOut);
@@ -808,10 +832,10 @@ EipStatus SendConnectedData(CipConnectionObject *connection_object) {
 
   /* assembleCPFData */
   common_packet_format_data->item_count = 2;
-  if(kConnectionObjectTransportClassTriggerTransportClass0 !=
-     ConnectionObjectGetTransportClassTriggerTransportClass(connection_object) )
+  if( kConnectionObjectTransportClassTriggerTransportClass0 !=
+      ConnectionObjectGetTransportClassTriggerTransportClass(connection_object) )
   /* use Sequenced Address Items if not Connection Class 0 */
-  {                                          
+  {
     common_packet_format_data->address_item.type_id =
       kCipItemIdSequencedAddressItem;
     common_packet_format_data->address_item.length = 8;
@@ -833,7 +857,7 @@ EipStatus SendConnectedData(CipConnectionObject *connection_object) {
   common_packet_format_data->data_item.length = 0;
 
   /* notify the application that data will be sent immediately after the call */
-  if(BeforeAssemblyDataSend(connection_object->producing_instance) ) {
+  if( BeforeAssemblyDataSend(connection_object->producing_instance) ) {
     /* the data has changed increase sequence counter */
     connection_object->sequence_count_producing++;
   }
@@ -855,8 +879,8 @@ EipStatus SendConnectedData(CipConnectionObject *connection_object) {
     common_packet_format_data->data_item.length += 4;
   }
 
-  if(kConnectionObjectTransportClassTriggerTransportClass1 ==
-     ConnectionObjectGetTransportClassTriggerTransportClass(connection_object) )
+  if( kConnectionObjectTransportClassTriggerTransportClass1 ==
+      ConnectionObjectGetTransportClassTriggerTransportClass(connection_object) )
   {
     common_packet_format_data->data_item.length += 2;
     AddIntToMessage(common_packet_format_data->data_item.length,
@@ -892,12 +916,12 @@ EipStatus HandleReceivedIoConnectionData(CipConnectionObject *connection_object,
   OPENER_TRACE_INFO("Starting data length: %d\n", data_length);
   bool no_new_data = false;
   /* check class 1 sequence number*/
-  if(kConnectionObjectTransportClassTriggerTransportClass1 ==
-     ConnectionObjectGetTransportClassTriggerTransportClass(connection_object) )
+  if( kConnectionObjectTransportClassTriggerTransportClass1 ==
+      ConnectionObjectGetTransportClassTriggerTransportClass(connection_object) )
   {
-    EipUint16 sequence_buffer = GetUintFromMessage(&(data) );
-    if(SEQ_LEQ16(sequence_buffer,
-                 connection_object->sequence_count_consuming) ) {
+    EipUint16 sequence_buffer = GetUintFromMessage( &(data) );
+    if( SEQ_LEQ16(sequence_buffer,
+                  connection_object->sequence_count_consuming) ) {
       no_new_data = true;
     }
     connection_object->sequence_count_consuming = sequence_buffer;
@@ -908,7 +932,7 @@ EipStatus HandleReceivedIoConnectionData(CipConnectionObject *connection_object,
   if(data_length > 0) {
     /* we have no heartbeat connection */
     if(s_consume_run_idle) {
-      EipUint32 nRunIdleBuf = GetUdintFromMessage(&(data) );
+      EipUint32 nRunIdleBuf = GetUdintFromMessage( &(data) );
       OPENER_TRACE_INFO("Run/Idle handler: 0x%x\n", nRunIdleBuf);
       const uint32_t kRunBitMask = 0x0001;
       if( (kRunBitMask & nRunIdleBuf) == 1 ) {
@@ -940,7 +964,7 @@ CipError OpenCommunicationChannels(CipConnectionObject *connection_object) {
 
   CipError cip_error = kCipErrorSuccess;
   CreateUdpSocket(); /* open UDP socket for IO messaging*/
-  
+
 /*get pointer to the CPF data, currently we have just one global instance of the struct. This may change in the future*/
   CipCommonPacketFormatData *common_packet_format_data =
     &g_common_packet_format_data_item;
@@ -975,7 +999,7 @@ CipError OpenCommunicationChannels(CipConnectionObject *connection_object) {
   }
 
   if(target_to_originator_connection_type ==
-     kConnectionObjectConnectionTypeMulticast)  
+     kConnectionObjectConnectionTypeMulticast)
   /* Multicast producing */
   {
     if(OpenProducingMulticastConnection(connection_object,
@@ -985,7 +1009,7 @@ CipError OpenCommunicationChannels(CipConnectionObject *connection_object) {
       return kCipErrorConnectionFailure;
     }
   } else if(target_to_originator_connection_type ==
-            kConnectionObjectConnectionTypePointToPoint)  
+            kConnectionObjectConnectionTypePointToPoint)
   /* Point to Point producing */
   {
 
@@ -1002,14 +1026,17 @@ CipError OpenCommunicationChannels(CipConnectionObject *connection_object) {
 void CloseCommunicationChannelsAndRemoveFromActiveConnectionsList(
   CipConnectionObject *connection_object) {
   if(kEipInvalidSocket !=
-      connection_object->socket[kUdpCommuncationDirectionConsuming])
+     connection_object->socket[kUdpCommuncationDirectionConsuming]) {
     CloseUdpSocket(connection_object->socket[kUdpCommuncationDirectionConsuming]);
+  }
 
   if(kEipInvalidSocket !=
-      connection_object->socket[kUdpCommuncationDirectionProducing])
+     connection_object->socket[kUdpCommuncationDirectionProducing]) {
     CloseUdpSocket(connection_object->socket[kUdpCommuncationDirectionProducing]);
+  }
 
   RemoveFromActiveConnections(connection_object);
   ConnectionObjectInitializeEmpty(connection_object);
-  OPENER_TRACE_INFO("cipioconnection: CloseCommunicationChannelsAndRemoveFromActiveConnectionsList\n");
+  OPENER_TRACE_INFO(
+    "cipioconnection: CloseCommunicationChannelsAndRemoveFromActiveConnectionsList\n");
 }

--- a/source/src/opener_api.h
+++ b/source/src/opener_api.h
@@ -78,7 +78,8 @@ void GetHostName(CipString *hostname);
  * @param major unsigned 8 bit major revision
  * @param minor unsigned 8 bit minor revision
  */
-void SetDeviceRevision(EipUint8 major, EipUint8 minor);
+void SetDeviceRevision(EipUint8 major,
+                       EipUint8 minor);
 
 /** @ingroup CIP_API
  * @brief Set the serial number of the device's identity object.
@@ -316,7 +317,7 @@ void InsertAttribute(CipInstance *const instance,
                      const EipUint16 attribute_number,
                      const EipUint8 cip_type,
                      CipAttributeEncodeInMessage encode_function,
-					 CipAttributeDecodeFromMessage decode_function,
+                     CipAttributeDecodeFromMessage decode_function,
                      void *const data,
                      const EipByte cip_flags);
 
@@ -470,76 +471,76 @@ void EncodeCipEthernetLinkPhyisicalAddress(const void *const data,
  *          -1 .. error
  */
 int DecodeCipBool(CipBool *const data,
-		const CipMessageRouterRequest *const message_router_request,
-		CipMessageRouterResponse *const message_router_response);
+                  const CipMessageRouterRequest *const message_router_request,
+                  CipMessageRouterResponse *const message_router_response);
 
 int DecodeCipByte(CipByte *const data,
-		const CipMessageRouterRequest *const message_router_request,
-		CipMessageRouterResponse *const message_router_response);
+                  const CipMessageRouterRequest *const message_router_request,
+                  CipMessageRouterResponse *const message_router_response);
 
 int DecodeCipByteArray(CipByteArray *const data,
-			const CipMessageRouterRequest *const message_router_request,
-			CipMessageRouterResponse *const message_router_response);
+                       const CipMessageRouterRequest *const message_router_request,
+                       CipMessageRouterResponse *const message_router_response);
 
 int DecodeCipWord(CipWord *const data,
-		const CipMessageRouterRequest *const message_router_request,
-		CipMessageRouterResponse *const message_router_response);
+                  const CipMessageRouterRequest *const message_router_request,
+                  CipMessageRouterResponse *const message_router_response);
 
 int DecodeCipDword(CipDword *const data,
-		const CipMessageRouterRequest *const message_router_request,
-		CipMessageRouterResponse *const message_router_response);
+                   const CipMessageRouterRequest *const message_router_request,
+                   CipMessageRouterResponse *const message_router_response);
 
 int DecodeCipLword(CipLword *const data,
-		const CipMessageRouterRequest *const message_router_request,
-		CipMessageRouterResponse *const message_router_response);
+                   const CipMessageRouterRequest *const message_router_request,
+                   CipMessageRouterResponse *const message_router_response);
 
 int DecodeCipUsint(CipUsint *const data,
-		const CipMessageRouterRequest *const message_router_request,
-		CipMessageRouterResponse *const message_router_response);
+                   const CipMessageRouterRequest *const message_router_request,
+                   CipMessageRouterResponse *const message_router_response);
 
 int DecodeCipUint(CipUint *const data,
-		const CipMessageRouterRequest *const message_router_request,
-		CipMessageRouterResponse *const message_router_response);
+                  const CipMessageRouterRequest *const message_router_request,
+                  CipMessageRouterResponse *const message_router_response);
 
 int DecodeCipUdint(CipUdint *const data,
-		const CipMessageRouterRequest *const message_router_request,
-		CipMessageRouterResponse *const message_router_response);
+                   const CipMessageRouterRequest *const message_router_request,
+                   CipMessageRouterResponse *const message_router_response);
 
 int DecodeCipUlint(CipUlint *const data,
-		const CipMessageRouterRequest *const message_router_request,
-		CipMessageRouterResponse *const message_router_response);
+                   const CipMessageRouterRequest *const message_router_request,
+                   CipMessageRouterResponse *const message_router_response);
 
 int DecodeCipSint(CipSint *const data,
-		const CipMessageRouterRequest *const message_router_request,
-		CipMessageRouterResponse *const message_router_response);
+                  const CipMessageRouterRequest *const message_router_request,
+                  CipMessageRouterResponse *const message_router_response);
 
 int DecodeCipInt(CipInt *const data,
-		const CipMessageRouterRequest *const message_router_request,
-		CipMessageRouterResponse *const message_router_response);
+                 const CipMessageRouterRequest *const message_router_request,
+                 CipMessageRouterResponse *const message_router_response);
 
 int DecodeCipDint(CipDint *const data,
-		const CipMessageRouterRequest *const message_router_request,
-		CipMessageRouterResponse *const message_router_response);
+                  const CipMessageRouterRequest *const message_router_request,
+                  CipMessageRouterResponse *const message_router_response);
 
 int DecodeCipLint(CipLint *const data,
-		const CipMessageRouterRequest *const message_router_request,
-		CipMessageRouterResponse *const message_router_response);
+                  const CipMessageRouterRequest *const message_router_request,
+                  CipMessageRouterResponse *const message_router_response);
 
 int DecodeCipReal(CipReal *const data,
-		const CipMessageRouterRequest *const message_router_request,
-		CipMessageRouterResponse *const message_router_response);
+                  const CipMessageRouterRequest *const message_router_request,
+                  CipMessageRouterResponse *const message_router_response);
 
 int DecodeCipLreal(CipLreal *const data,
-		const CipMessageRouterRequest *const message_router_request,
-		CipMessageRouterResponse *const message_router_response);
+                   const CipMessageRouterRequest *const message_router_request,
+                   CipMessageRouterResponse *const message_router_response);
 
 int DecodeCipString(CipString *const data,
-		const CipMessageRouterRequest *const message_router_request,
-		CipMessageRouterResponse *const message_router_response);
+                    const CipMessageRouterRequest *const message_router_request,
+                    CipMessageRouterResponse *const message_router_response);
 
 int DecodeCipShortString(CipShortString *const data,
-		const CipMessageRouterRequest *const message_router_request,
-		CipMessageRouterResponse *const message_router_response);
+                         const CipMessageRouterRequest *const message_router_request,
+                         CipMessageRouterResponse *const message_router_response);
 
 /** @ingroup CIP_API
  * @brief Create an instance of an assembly object
@@ -614,12 +615,12 @@ typedef EipStatus (*ConnectionSendDataFunction)(CipConnectionObject *
  * @return Stack status
  */
 typedef EipStatus (*ConnectionReceiveDataFunction)(CipConnectionObject *
-                                                  connection_object,
-                                                  const EipUint8 *data,
-                                                  const EipUint16 data_length);
+                                                   connection_object,
+                                                   const EipUint8 *data,
+                                                   const EipUint16 data_length);
 
- /** @ingroup CIP_API
- * @brief Function pointer for timeout checker functions 
+/** @ingroup CIP_API
+ * @brief Function pointer for timeout checker functions
  *
  * @param elapsed_time elapsed time since last check
  */
@@ -751,8 +752,8 @@ EipStatus HandleReceivedExplictUdpData(const int socket_handle,
  *  @return EIP_OK on success
  */
 EipStatus HandleReceivedConnectedData(const EipUint8 *const received_data,
-                            int received_data_length,
-                            struct sockaddr_in *from_address);
+                                      int received_data_length,
+                                      struct sockaddr_in *from_address);
 
 /** @ingroup CIP_API
  * @brief Check if any of the connection timers (TransmissionTrigger or
@@ -789,7 +790,7 @@ EipStatus ManageConnections(MilliSeconds elapsed_time);
  * @return EIP_OK on success
  */
 EipStatus TriggerConnections(unsigned int output_assembly_id,
-                   unsigned int input_assembly_id);
+                             unsigned int input_assembly_id);
 
 /** @ingroup CIP_API
  * @brief Inform the encapsulation layer that the remote host has closed the
@@ -927,10 +928,10 @@ void CipFree(void *data);
 void RunIdleChanged(EipUint32 run_idle_value);
 
 /** @ingroup CIP_CALLBACK_API
- * @brief Create the UDP socket for the implicit IO messaging, 
+ * @brief Create the UDP socket for the implicit IO messaging,
  * one socket handles all connections
  * @return the socket handle if successful, else kEipInvalidSocket
-*/ 
+ */
 int CreateUdpSocket(void);
 
 /** @ingroup CIP_CALLBACK_API
@@ -940,7 +941,7 @@ int CreateUdpSocket(void);
  * @return kEipStatusOk on success
  */
 EipStatus SendUdpData(const struct sockaddr_in *const socket_data,
-            const ENIPMessage *const outgoing_message);
+                      const ENIPMessage *const outgoing_message);
 
 /** @ingroup CIP_CALLBACK_API
  * @brief Close the given socket and clean up the stack

--- a/source/src/ports/generic_networkhandler.c
+++ b/source/src/ports/generic_networkhandler.c
@@ -52,7 +52,8 @@ const uint16_t kOpenerEthernetPort = 0xAF12;
 
 #ifndef MSG_NOSIGNAL
 #define MSG_NOSIGNAL 0
-#define MSG_NOSIGNAL_PRAGMA_MESSAGE "MSG_NOSIGNAL not defined. Check if your system stops on SIGPIPE, as this can happen with the send() function"
+#define MSG_NOSIGNAL_PRAGMA_MESSAGE \
+  "MSG_NOSIGNAL not defined. Check if your system stops on SIGPIPE, as this can happen with the send() function"
 #if defined(_WIN32)
 #pragma message(MSG_NOSIGNAL_PRAGMA_MESSAGE)
 #else
@@ -67,7 +68,7 @@ SocketTimer g_timestamps[OPENER_NUMBER_OF_SUPPORTED_SESSIONS];
 fd_set master_socket;
 fd_set read_socket;
 
-int highest_socket_handle; 
+int highest_socket_handle;
 int g_current_active_tcp_socket;
 
 struct timeval g_time_value;
@@ -78,7 +79,7 @@ NetworkStatus g_network_status;
 
 /** @brief Size of the timeout checker function pointer array
  */
-#define OPENER_TIMEOUT_CHECKER_ARRAY_SIZE 10 
+#define OPENER_TIMEOUT_CHECKER_ARRAY_SIZE 10
 
 /** @brief function pointer array for timer checker functions
  */
@@ -121,7 +122,7 @@ void RemoveSocketTimerFromList(const int socket_handle);
 
 EipStatus NetworkHandlerInitialize(void) {
 
-  if(kEipStatusOk != NetworkHandlerInitializePlatform() ) {
+  if( kEipStatusOk != NetworkHandlerInitializePlatform() ) {
     return kEipStatusError;
   }
 
@@ -142,129 +143,138 @@ EipStatus NetworkHandlerInitialize(void) {
   FD_ZERO(&read_socket);
 
   /* create a new TCP socket */
-  if( (g_network_status.tcp_listener =
-         socket(AF_INET, SOCK_STREAM, IPPROTO_TCP) ) == -1 ) {
+  if( ( g_network_status.tcp_listener =
+          socket(AF_INET, SOCK_STREAM, IPPROTO_TCP) ) == -1 ) {
     int error_code = GetSocketErrorNumber();
     char *error_message = GetErrorMessage(error_code);
-    OPENER_TRACE_ERR("networkhandler tcp_listener: error allocating socket, %d - %s\n",
-        error_code,
-        error_message);
+    OPENER_TRACE_ERR(
+      "networkhandler tcp_listener: error allocating socket, %d - %s\n",
+      error_code,
+      error_message);
     FreeErrorMessage(error_message);
     return kEipStatusError;
   }
 
   int set_socket_option_value = 1; //Represents true for used set socket options
   /* Activates address reuse */
-  if(setsockopt(g_network_status.tcp_listener, SOL_SOCKET, SO_REUSEADDR,
-                (char *) &set_socket_option_value,
-                sizeof(set_socket_option_value) ) == -1) {
+  if(setsockopt( g_network_status.tcp_listener, SOL_SOCKET, SO_REUSEADDR,
+                 (char *) &set_socket_option_value,
+                 sizeof(set_socket_option_value) ) == -1) {
     OPENER_TRACE_ERR(
-        "networkhandler tcp_listener: error setting socket option SO_REUSEADDR\n");
+      "networkhandler tcp_listener: error setting socket option SO_REUSEADDR\n");
     return kEipStatusError;
   }
 
   if(SetSocketToNonBlocking(g_network_status.tcp_listener) < 0) {
     OPENER_TRACE_ERR(
-        "networkhandler tcp_listener: error setting socket to non-blocking on new socket\n");
+      "networkhandler tcp_listener: error setting socket to non-blocking on new socket\n");
     return kEipStatusError;
   }
 
   /* create a new UDP socket */
-  if( (g_network_status.udp_global_broadcast_listener =
-         socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP) ) == kEipInvalidSocket ) {
+  if( ( g_network_status.udp_global_broadcast_listener =
+          socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP) ) == kEipInvalidSocket ) {
     int error_code = GetSocketErrorNumber();
     char *error_message = GetErrorMessage(error_code);
     OPENER_TRACE_ERR(
-        "networkhandler udp_global_broadcast_listener: error allocating socket, %d - %s\n",
-        error_code,
-        error_message);
+      "networkhandler udp_global_broadcast_listener: error allocating socket, %d - %s\n",
+      error_code,
+      error_message);
     FreeErrorMessage(error_message);
     return kEipStatusError;
   }
 
   /* create a new UDP socket */
-  if( (g_network_status.udp_unicast_listener =
-         socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP) ) == kEipInvalidSocket ) {
+  if( ( g_network_status.udp_unicast_listener =
+          socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP) ) == kEipInvalidSocket ) {
     int error_code = GetSocketErrorNumber();
     char *error_message = GetErrorMessage(error_code);
-    OPENER_TRACE_ERR("networkhandler udp_unicast_listener: error allocating socket, %d - %s\n",
-        error_code, error_message);
+    OPENER_TRACE_ERR(
+      "networkhandler udp_unicast_listener: error allocating socket, %d - %s\n",
+      error_code,
+      error_message);
     FreeErrorMessage(error_message);
     return kEipStatusError;
   }
 
   /* Activates address reuse */
   set_socket_option_value = 1;
-  if(setsockopt(g_network_status.udp_global_broadcast_listener, SOL_SOCKET,
-                SO_REUSEADDR, (char *) &set_socket_option_value,
-                sizeof(set_socket_option_value) )
+  if(setsockopt( g_network_status.udp_global_broadcast_listener, SOL_SOCKET,
+                 SO_REUSEADDR, (char *) &set_socket_option_value,
+                 sizeof(set_socket_option_value) )
      == -1) {
     OPENER_TRACE_ERR(
-        "networkhandler udp_global_broadcast_listener: error setting socket option SO_REUSEADDR\n");
+      "networkhandler udp_global_broadcast_listener: error setting socket option SO_REUSEADDR\n");
     return kEipStatusError;
   }
 
   if(SetSocketToNonBlocking(g_network_status.udp_global_broadcast_listener) <
      0) {
     OPENER_TRACE_ERR(
-        "networkhandler udp_global_broadcast_listener: error setting socket to non-blocking on new socket\n");
+      "networkhandler udp_global_broadcast_listener: error setting socket to non-blocking on new socket\n");
     return kEipStatusError;
   }
 
   /* Activates address reuse */
   set_socket_option_value = 1;
-  if(setsockopt(g_network_status.udp_unicast_listener, SOL_SOCKET, SO_REUSEADDR,
-                (char *) &set_socket_option_value,
-                sizeof(set_socket_option_value) ) == -1) {
+  if(setsockopt( g_network_status.udp_unicast_listener, SOL_SOCKET,
+                 SO_REUSEADDR,
+                 (char *) &set_socket_option_value,
+                 sizeof(set_socket_option_value) ) == -1) {
     OPENER_TRACE_ERR(
-        "networkhandler udp_unicast_listener: error setting socket option SO_REUSEADDR\n");
+      "networkhandler udp_unicast_listener: error setting socket option SO_REUSEADDR\n");
     return kEipStatusError;
   }
 
   if(SetSocketToNonBlocking(g_network_status.udp_unicast_listener) < 0) {
     OPENER_TRACE_ERR(
-        "networkhandler udp_unicast_listener: error setting socket to non-blocking\n");
+      "networkhandler udp_unicast_listener: error setting socket to non-blocking\n");
     return kEipStatusError;
   }
 
   struct sockaddr_in my_address = {
     .sin_family = AF_INET,
     .sin_port = htons(kOpenerEthernetPort),
-    .sin_addr.s_addr = g_network_status.ip_address};
+    .sin_addr.s_addr = g_network_status.ip_address
+  };
 
   /* bind the new socket to port 0xAF12 (CIP) */
-  if( (bind(g_network_status.tcp_listener, (struct sockaddr *) &my_address,
-            sizeof(struct sockaddr) ) ) == -1 ) {
+  if( ( bind( g_network_status.tcp_listener, (struct sockaddr *) &my_address,
+              sizeof(struct sockaddr) ) ) == -1 ) {
     int error_code = GetSocketErrorNumber();
     char *error_message = GetErrorMessage(error_code);
-    OPENER_TRACE_ERR("networkhandler tcp_listener: error with TCP bind: %d - %s\n", error_code,
-        error_message);
+    OPENER_TRACE_ERR(
+      "networkhandler tcp_listener: error with TCP bind: %d - %s\n",
+      error_code,
+      error_message);
     FreeErrorMessage(error_message);
     return kEipStatusError;
   }
 
-  if( (bind(g_network_status.udp_unicast_listener,
-            (struct sockaddr *) &my_address,
-            sizeof(struct sockaddr) ) ) == -1 ) {
+  if( ( bind( g_network_status.udp_unicast_listener,
+              (struct sockaddr *) &my_address,
+              sizeof(struct sockaddr) ) ) == -1 ) {
     int error_code = GetSocketErrorNumber();
     char *error_message = GetErrorMessage(error_code);
-    OPENER_TRACE_ERR( "networkhandler udp_unicast_listener: error with UDP bind: %d - %s\n",
-        error_code, error_message);
+    OPENER_TRACE_ERR(
+      "networkhandler udp_unicast_listener: error with UDP bind: %d - %s\n",
+      error_code,
+      error_message);
     FreeErrorMessage(error_message);
     return kEipStatusError;
   }
 
   /* have QoS DSCP explicit appear on UDP responses to unicast messages */
-  if(SetQosOnSocket(g_network_status.udp_unicast_listener,
-                    CipQosGetDscpPriority(kConnectionObjectPriorityExplicit) )
+  if(SetQosOnSocket( g_network_status.udp_unicast_listener,
+                     CipQosGetDscpPriority(kConnectionObjectPriorityExplicit) )
      != 0) {
     int error_code = GetSocketErrorNumber();
     char *error_message = GetErrorMessage(error_code);
     OPENER_TRACE_ERR(
-        "networkhandler udp_unicast_listener: error set QoS %d: %d - %s\n",
-        g_network_status.udp_unicast_listener,
-        error_code,
-        error_message);
+      "networkhandler udp_unicast_listener: error set QoS %d: %d - %s\n",
+      g_network_status.udp_unicast_listener,
+      error_code,
+      error_message);
     FreeErrorMessage(error_message);
     /* print message but don't abort by intent */
   }
@@ -272,46 +282,49 @@ EipStatus NetworkHandlerInitialize(void) {
   struct sockaddr_in global_broadcast_address = {
     .sin_family = AF_INET,
     .sin_port = htons(kOpenerEthernetPort),
-    .sin_addr.s_addr = htonl(INADDR_ANY)};
+    .sin_addr.s_addr = htonl(INADDR_ANY)
+  };
 
   /* enable the UDP socket to receive broadcast messages */
   set_socket_option_value = 1;
-  if(0 >
-     setsockopt(g_network_status.udp_global_broadcast_listener, SOL_SOCKET,
-                SO_BROADCAST, (char *) &set_socket_option_value,
-                sizeof(int) ) ) {
+  if( 0 >
+      setsockopt( g_network_status.udp_global_broadcast_listener, SOL_SOCKET,
+                  SO_BROADCAST, (char *) &set_socket_option_value,
+                  sizeof(int) ) ) {
     int error_code = GetSocketErrorNumber();
     char *error_message = GetErrorMessage(error_code);
     OPENER_TRACE_ERR(
-        "networkhandler udp_global_broadcast_listener: error with setting broadcast receive: %d - %s\n",
-        error_code, error_message);
+      "networkhandler udp_global_broadcast_listener: error with setting broadcast receive: %d - %s\n",
+      error_code,
+      error_message);
     FreeErrorMessage(error_message);
     return kEipStatusError;
   }
 
-  if( (bind(g_network_status.udp_global_broadcast_listener,
-            (struct sockaddr *) &global_broadcast_address,
-            sizeof(struct sockaddr) ) ) == -1 ) {
+  if( ( bind( g_network_status.udp_global_broadcast_listener,
+              (struct sockaddr *) &global_broadcast_address,
+              sizeof(struct sockaddr) ) ) == -1 ) {
     int error_code = GetSocketErrorNumber();
     char *error_message = GetErrorMessage(error_code);
-    OPENER_TRACE_ERR("networkhandler udp_global_broadcast_listener: error with UDP bind: %d - %s\n",
-        error_code,
-        error_message);
+    OPENER_TRACE_ERR(
+      "networkhandler udp_global_broadcast_listener: error with UDP bind: %d - %s\n",
+      error_code,
+      error_message);
     FreeErrorMessage(error_message);
     return kEipStatusError;
   }
 
   /* have QoS DSCP explicit appear on UDP responses to broadcast messages */
-  if(SetQosOnSocket(g_network_status.udp_global_broadcast_listener,
-                    CipQosGetDscpPriority(kConnectionObjectPriorityExplicit) )
+  if(SetQosOnSocket( g_network_status.udp_global_broadcast_listener,
+                     CipQosGetDscpPriority(kConnectionObjectPriorityExplicit) )
      != 0) {
     int error_code = GetSocketErrorNumber();
     char *error_message = GetErrorMessage(error_code);
     OPENER_TRACE_ERR(
-        "networkhandler udp_global_broadcast_listener: error set QoS %d: %d - %s\n",
-        g_network_status.udp_global_broadcast_listener,
-        error_code,
-        error_message);
+      "networkhandler udp_global_broadcast_listener: error set QoS %d: %d - %s\n",
+      g_network_status.udp_global_broadcast_listener,
+      error_code,
+      error_message);
     FreeErrorMessage(error_message);
     /* print message but don't abort by intent */
   }
@@ -319,28 +332,29 @@ EipStatus NetworkHandlerInitialize(void) {
   /* Make QoS DSCP explicit already appear on SYN connection establishment.
    * A newly accept()ed TCP socket inherits the setting from this socket.
    */
-  if(SetQosOnSocket(g_network_status.tcp_listener,
-                    CipQosGetDscpPriority(kConnectionObjectPriorityExplicit) )
+  if(SetQosOnSocket( g_network_status.tcp_listener,
+                     CipQosGetDscpPriority(kConnectionObjectPriorityExplicit) )
      != 0) {
     int error_code = GetSocketErrorNumber();
     char *error_message = GetErrorMessage(error_code);
     OPENER_TRACE_ERR(
-        "networkhandler tcp_listener: error set QoS %d: %d - %s\n",
-        g_network_status.tcp_listener,
-        error_code,
-        error_message);
+      "networkhandler tcp_listener: error set QoS %d: %d - %s\n",
+      g_network_status.tcp_listener,
+      error_code,
+      error_message);
     FreeErrorMessage(error_message);
     /* print message but don't abort by intent */
   }
 
   /* switch socket in listen mode */
-  if( (listen(g_network_status.tcp_listener,
-              MAX_NO_OF_TCP_SOCKETS) ) == -1 ) {
+  if( ( listen(g_network_status.tcp_listener,
+               MAX_NO_OF_TCP_SOCKETS) ) == -1 ) {
     int error_code = GetSocketErrorNumber();
     char *error_message = GetErrorMessage(error_code);
-    OPENER_TRACE_ERR("networkhandler tcp_listener: error with listen: %d - %s\n",
-        error_code,
-        error_message);
+    OPENER_TRACE_ERR(
+      "networkhandler tcp_listener: error with listen: %d - %s\n",
+      error_code,
+      error_message);
     FreeErrorMessage(error_message);
     return kEipStatusError;
   }
@@ -376,9 +390,9 @@ void CloseTcpSocket(int socket_handle) {
 
 void RemoveSocketTimerFromList(const int socket_handle) {
   SocketTimer *socket_timer = NULL;
-  while(NULL != (socket_timer = SocketTimerArrayGetSocketTimer(g_timestamps,
-                                                               OPENER_NUMBER_OF_SUPPORTED_SESSIONS,
-                                                               socket_handle) ) )
+  while( NULL != ( socket_timer = SocketTimerArrayGetSocketTimer(g_timestamps,
+                                                                 OPENER_NUMBER_OF_SUPPORTED_SESSIONS,
+                                                                 socket_handle) ) )
   {
     SocketTimerClear(socket_timer);
   }
@@ -386,8 +400,8 @@ void RemoveSocketTimerFromList(const int socket_handle) {
 
 EipBool8 CheckSocketSet(int socket) {
   EipBool8 return_value = false;
-  if(FD_ISSET(socket, &read_socket) ) {
-    if(FD_ISSET(socket, &master_socket) ) {
+  if( FD_ISSET(socket, &read_socket) ) {
+    if( FD_ISSET(socket, &master_socket) ) {
       return_value = true;
     } else {
       OPENER_TRACE_INFO("socket: %d closed with pending message\n", socket);
@@ -401,7 +415,7 @@ EipBool8 CheckSocketSet(int socket) {
 void CheckAndHandleTcpListenerSocket(void) {
   int new_socket = kEipInvalidSocket;
   /* see if this is a connection request to the TCP listener*/
-  if(true == CheckSocketSet(g_network_status.tcp_listener) ) {
+  if( true == CheckSocketSet(g_network_status.tcp_listener) ) {
     OPENER_TRACE_INFO("networkhandler: new TCP connection\n");
 
     new_socket = accept(g_network_status.tcp_listener, NULL, NULL);
@@ -480,9 +494,9 @@ EipStatus NetworkHandlerProcessCyclic(void) {
     CheckAndHandleConsumingUdpSocket();
 
     for(int socket = 0; socket <= highest_socket_handle; socket++) {
-      if(true == CheckSocketSet(socket) ) {
+      if( true == CheckSocketSet(socket) ) {
         /* if it is still checked it is a TCP receive */
-        if(kEipStatusError == HandleDataOnTcpSocket(socket) ) /* if error */
+        if( kEipStatusError == HandleDataOnTcpSocket(socket) ) /* if error */
         {
           CloseTcpSocket(socket);
           RemoveSession(socket); /* clean up session and close the socket */
@@ -531,7 +545,7 @@ EipStatus NetworkHandlerFinish(void) {
 
 void CheckAndHandleUdpGlobalBroadcastSocket(void) {
   /* see if this is an unsolicited inbound UDP message */
-  if(true == CheckSocketSet(g_network_status.udp_global_broadcast_listener) ) {
+  if( true == CheckSocketSet(g_network_status.udp_global_broadcast_listener) ) {
     struct sockaddr_in from_address = { 0 };
     socklen_t from_address_length = sizeof(from_address);
 
@@ -564,40 +578,42 @@ void CheckAndHandleUdpGlobalBroadcastSocket(void) {
     int remaining_bytes = 0;
     ENIPMessage outgoing_message;
     InitializeENIPMessage(&outgoing_message);
-    do {
-      EipStatus need_to_send = HandleReceivedExplictUdpData(
-        g_network_status.udp_unicast_listener,
-        /* sending from unicast port, due to strange behavior of the broadcast port */
-        &from_address,
-        receive_buffer,
-        received_size,
-        &remaining_bytes,
-        false,
-        &outgoing_message);
+    EipStatus need_to_send = HandleReceivedExplictUdpData(
+      g_network_status.udp_unicast_listener,
+      /* sending from unicast port, due to strange behavior of the broadcast port */
+      &from_address,
+      receive_buffer,
+      received_size,
+      &remaining_bytes,
+      false,
+      &outgoing_message);
 
-      receive_buffer += received_size - remaining_bytes;
-      received_size = remaining_bytes;
+    receive_buffer += received_size - remaining_bytes;
+    received_size = remaining_bytes;
 
-      if(need_to_send > 0) {
-        OPENER_TRACE_INFO("UDP broadcast reply sent:\n");
+    if(need_to_send > 0) {
+      OPENER_TRACE_INFO("UDP broadcast reply sent:\n");
 
-        /* if the active socket matches a registered UDP callback, handle a UDP packet */
-        if(sendto(g_network_status.udp_unicast_listener, /* sending from unicast port, due to strange behavior of the broadcast port */
-                  (char *) outgoing_message.message_buffer,
-                  outgoing_message.used_message_length, 0,
-                  (struct sockaddr *) &from_address, sizeof(from_address) )
-           != outgoing_message.used_message_length) {
-          OPENER_TRACE_INFO(
-            "networkhandler: UDP response was not fully sent\n");
-        }
+      /* if the active socket matches a registered UDP callback, handle a UDP packet */
+      if(sendto( g_network_status.udp_unicast_listener,  /* sending from unicast port, due to strange behavior of the broadcast port */
+                 (char *) outgoing_message.message_buffer,
+                 outgoing_message.used_message_length, 0,
+                 (struct sockaddr *) &from_address, sizeof(from_address) )
+         != outgoing_message.used_message_length) {
+        OPENER_TRACE_INFO(
+          "networkhandler: UDP response was not fully sent\n");
       }
-    } while(remaining_bytes > 0);
+    }
+    if(remaining_bytes > 0) {
+      OPENER_TRACE_ERR("Request on broadcast UDP port had too many data (%d)",
+                       remaining_bytes);
+    }
   }
 }
 
 void CheckAndHandleUdpUnicastSocket(void) {
   /* see if this is an unsolicited inbound UDP message */
-  if(true == CheckSocketSet(g_network_status.udp_unicast_listener) ) {
+  if( true == CheckSocketSet(g_network_status.udp_unicast_listener) ) {
 
     struct sockaddr_in from_address = { 0 };
     socklen_t from_address_length = sizeof(from_address);
@@ -631,34 +647,37 @@ void CheckAndHandleUdpUnicastSocket(void) {
     int remaining_bytes = 0;
     ENIPMessage outgoing_message;
     InitializeENIPMessage(&outgoing_message);
-    do {
-      EipStatus need_to_send = HandleReceivedExplictUdpData(
-        g_network_status.udp_unicast_listener,
-        &from_address,
-        receive_buffer,
-        received_size,
-        &remaining_bytes,
-        true,
-        &outgoing_message);
+    EipStatus need_to_send = HandleReceivedExplictUdpData(
+      g_network_status.udp_unicast_listener,
+      &from_address,
+      receive_buffer,
+      received_size,
+      &remaining_bytes,
+      true,
+      &outgoing_message);
 
-      receive_buffer += received_size - remaining_bytes;
-      received_size = remaining_bytes;
+    receive_buffer += received_size - remaining_bytes;
+    received_size = remaining_bytes;
 
-      if(need_to_send > 0) {
-        OPENER_TRACE_INFO("UDP unicast reply sent:\n");
+    if(need_to_send > 0) {
+      OPENER_TRACE_INFO("UDP unicast reply sent:\n");
 
-        /* if the active socket matches a registered UDP callback, handle a UDP packet */
-        if(sendto(g_network_status.udp_unicast_listener,
-                  (char *) outgoing_message.message_buffer,
-                  outgoing_message.used_message_length, 0,
-                  (struct sockaddr *) &from_address,
-                  sizeof(from_address) ) !=
-           outgoing_message.used_message_length) {
-          OPENER_TRACE_INFO(
-            "networkhandler: UDP unicast response was not fully sent\n");
-        }
+      /* if the active socket matches a registered UDP callback, handle a UDP packet */
+      if(sendto( g_network_status.udp_unicast_listener,
+                 (char *) outgoing_message.message_buffer,
+                 outgoing_message.used_message_length, 0,
+                 (struct sockaddr *) &from_address,
+                 sizeof(from_address) ) !=
+         outgoing_message.used_message_length) {
+        OPENER_TRACE_INFO(
+          "networkhandler: UDP unicast response was not fully sent\n");
       }
-    } while(remaining_bytes > 0);
+    }
+    if (remaining_bytes > 0) {
+      OPENER_TRACE_ERR(
+        "Request on broadcast UDP port had too many data (%d)",
+        remaining_bytes);
+    }
   }
 }
 
@@ -669,22 +688,22 @@ EipStatus SendUdpData(const struct sockaddr_in *const address,
 #if defined(OPENER_TRACE_ENABLED)
   static char ip_str[INET_ADDRSTRLEN];
   OPENER_TRACE_INFO(
-      "UDP packet to be sent to: %s:%d\n",
-      inet_ntop(AF_INET, &address->sin_addr, ip_str, sizeof ip_str),
-      ntohs(address->sin_port));
+    "UDP packet to be sent to: %s:%d\n",
+    inet_ntop(AF_INET, &address->sin_addr, ip_str, sizeof ip_str),
+    ntohs(address->sin_port) );
 #endif
 
-  int sent_length = sendto(g_network_status.udp_io_messaging,
-                           (char *)outgoing_message->message_buffer,
+  int sent_length = sendto( g_network_status.udp_io_messaging,
+                            (char *)outgoing_message->message_buffer,
                             outgoing_message->used_message_length, 0,
-                            (struct sockaddr*) address, sizeof(*address));
+                            (struct sockaddr *) address, sizeof(*address) );
   if(sent_length < 0) {
     int error_code = GetSocketErrorNumber();
     char *error_message = GetErrorMessage(error_code);
     OPENER_TRACE_ERR(
-        "networkhandler: error with sendto in SendUDPData: %d - %s\n",
-        error_code,
-        error_message);
+      "networkhandler: error with sendto in SendUDPData: %d - %s\n",
+      error_code,
+      error_message);
     FreeErrorMessage(error_message);
     return kEipStatusError;
   }
@@ -720,7 +739,9 @@ EipStatus HandleDataOnTcpSocket(int socket) {
                                                                    OPENER_NUMBER_OF_SUPPORTED_SESSIONS,
                                                                    socket);
   if(number_of_read_bytes == 0) {
-    OPENER_TRACE_ERR("networkhandler: socket: %d - connection closed by client.\n", socket);
+    OPENER_TRACE_ERR(
+      "networkhandler: socket: %d - connection closed by client.\n",
+      socket);
     RemoveSocketTimerFromList(socket);
     RemoveSession(socket);
     return kEipStatusError;
@@ -829,7 +850,7 @@ EipStatus HandleDataOnTcpSocket(int socket) {
     g_current_active_tcp_socket = socket;
 
     struct sockaddr sender_address;
-    memset(&sender_address, 0, sizeof(sender_address) );
+    memset( &sender_address, 0, sizeof(sender_address) );
     socklen_t fromlen = sizeof(sender_address);
     if(getpeername(socket, (struct sockaddr *) &sender_address, &fromlen) < 0) {
       int error_code = GetSocketErrorNumber();
@@ -910,7 +931,7 @@ int CreateUdpSocket(void) {
 
   if (SetSocketToNonBlocking(g_network_status.udp_io_messaging) < 0) {
     OPENER_TRACE_ERR(
-        "networkhandler udp_io_messaging: error setting socket to non-blocking on new socket\n");
+      "networkhandler udp_io_messaging: error setting socket to non-blocking on new socket\n");
     CloseUdpSocket(g_network_status.udp_io_messaging);
     OPENER_ASSERT(false);/* This should never happen! */
     return kEipInvalidSocket;
@@ -920,10 +941,10 @@ int CreateUdpSocket(void) {
                     g_network_status.udp_io_messaging);
 
   int option_value = 1;
-  if (setsockopt(g_network_status.udp_io_messaging, SOL_SOCKET, SO_REUSEADDR,
-                 (char *)&option_value, sizeof(option_value)) < 0) {
+  if (setsockopt( g_network_status.udp_io_messaging, SOL_SOCKET, SO_REUSEADDR,
+                  (char *)&option_value, sizeof(option_value) ) < 0) {
     OPENER_TRACE_ERR(
-        "error setting socket option SO_REUSEADDR on %s UDP socket\n");
+      "error setting socket option SO_REUSEADDR on %s UDP socket\n");
     CloseUdpSocket(g_network_status.udp_io_messaging);
     return kEipInvalidSocket;
   }
@@ -932,14 +953,16 @@ int CreateUdpSocket(void) {
   struct sockaddr_in source_addr = {
     .sin_family = AF_INET,
     .sin_addr.s_addr = htonl(INADDR_ANY),
-    .sin_port = htons(kOpenerEipIoUdpPort)};
-  
-  if (bind(g_network_status.udp_io_messaging, (struct sockaddr *)&source_addr,
-           sizeof(source_addr)) < 0) {
+    .sin_port = htons(kOpenerEipIoUdpPort)
+  };
+
+  if (bind( g_network_status.udp_io_messaging, (struct sockaddr *)&source_addr,
+            sizeof(source_addr) ) < 0) {
     int error_code = GetSocketErrorNumber();
     char *error_message = GetErrorMessage(error_code);
-    OPENER_TRACE_ERR("error on bind UDP for producing messages: %d - %s\n", error_code,
-        error_message);
+    OPENER_TRACE_ERR("error on bind UDP for producing messages: %d - %s\n",
+                     error_code,
+                     error_message);
     FreeErrorMessage(error_message);
     CloseUdpSocket(g_network_status.udp_io_messaging);
     return kEipInvalidSocket;
@@ -947,7 +970,7 @@ int CreateUdpSocket(void) {
 
   /* add new socket to the master list */
   FD_SET(g_network_status.udp_io_messaging, &master_socket);
- 
+
   if (g_network_status.udp_io_messaging > highest_socket_handle) {
     OPENER_TRACE_INFO("New highest socket: %d\n",
                       g_network_status.udp_io_messaging);
@@ -960,8 +983,8 @@ int CreateUdpSocket(void) {
  *
  * @return 0 if successful, else the error code */
 int SetQos(CipUsint qos_for_socket) {
-  if (SetQosOnSocket(g_network_status.udp_io_messaging,
-                     CipQosGetDscpPriority(qos_for_socket)) !=
+  if (SetQosOnSocket( g_network_status.udp_io_messaging,
+                      CipQosGetDscpPriority(qos_for_socket) ) !=
       0) { /* got error */
     int error_code = GetSocketErrorNumber();
     char *error_message = GetErrorMessage(error_code);
@@ -976,31 +999,31 @@ int SetQos(CipUsint qos_for_socket) {
  *
  * @return 0 if successful, else the error code */
 int SetSocketOptionsMulticastProduce(void) {
-  if (g_tcpip.mcast_ttl_value != 1) { 
+  if (g_tcpip.mcast_ttl_value != 1) {
     /* we need to set a TTL value for the socket */
-    if (setsockopt(g_network_status.udp_io_messaging, IPPROTO_IP,
-                   IP_MULTICAST_TTL, NWBUF_CAST & g_tcpip.mcast_ttl_value,
-                   sizeof(g_tcpip.mcast_ttl_value)) < 0) {
+    if (setsockopt( g_network_status.udp_io_messaging, IPPROTO_IP,
+                    IP_MULTICAST_TTL, NWBUF_CAST & g_tcpip.mcast_ttl_value,
+                    sizeof(g_tcpip.mcast_ttl_value) ) < 0) {
       int error_code = GetSocketErrorNumber();
       char *error_message = GetErrorMessage(error_code);
       OPENER_TRACE_ERR(
-          "networkhandler: could not set the TTL to: %d, error: %d - %s\n",
-          g_tcpip.mcast_ttl_value, error_code, error_message);
+        "networkhandler: could not set the TTL to: %d, error: %d - %s\n",
+        g_tcpip.mcast_ttl_value, error_code, error_message);
       FreeErrorMessage(error_message);
       return error_code;
     }
   }
   /* Need to specify the interface for outgoing multicast packets on a
-   device with multiple interfaces. */
+     device with multiple interfaces. */
   struct in_addr my_addr = {.s_addr = g_network_status.ip_address};
   if (setsockopt(g_network_status.udp_io_messaging, IPPROTO_IP, IP_MULTICAST_IF,
                  NWBUF_CAST & my_addr.s_addr, sizeof my_addr.s_addr) < 0) {
     int error_code = GetSocketErrorNumber();
     char *error_message = GetErrorMessage(error_code);
     OPENER_TRACE_ERR(
-        "networkhandler: could not set the multicast interface, error: %d "
-        "- %s\n",
-        error_code, error_message);
+      "networkhandler: could not set the multicast interface, error: %d "
+      "- %s\n",
+      error_code, error_message);
     FreeErrorMessage(error_message);
     return error_code;
   }
@@ -1038,17 +1061,21 @@ void CheckAndHandleConsumingUdpSocket(void) {
 
     if( (kEipInvalidSocket !=
          current_connection_object->socket[kUdpCommuncationDirectionConsuming])
-        && (true ==
-            CheckSocketSet(current_connection_object->socket[
-                             kUdpCommuncationDirectionConsuming
-                           ]) ) ) {
+        && ( true ==
+             CheckSocketSet(current_connection_object->socket[
+                              kUdpCommuncationDirectionConsuming
+                            ]) ) ) {
       OPENER_TRACE_INFO("Processing UDP consuming message\n");
       struct sockaddr_in from_address = { 0 };
       socklen_t from_address_length = sizeof(from_address);
       CipOctet incoming_message[PC_OPENER_ETHERNET_BUFFER_SIZE] = { 0 };
 
-      int received_size = recvfrom(g_network_status.udp_io_messaging, NWBUF_CAST incoming_message, sizeof(incoming_message),
-        0, (struct sockaddr*) &from_address, &from_address_length);
+      int received_size = recvfrom(g_network_status.udp_io_messaging,
+                                   NWBUF_CAST incoming_message,
+                                   sizeof(incoming_message),
+                                   0,
+                                   (struct sockaddr *) &from_address,
+                                   &from_address_length);
       if(0 == received_size) {
         int error_code = GetSocketErrorNumber();
         char *error_message = GetErrorMessage(error_code);
@@ -1127,8 +1154,8 @@ void CheckEncapsulationInactivity(int socket_handle) {
       MilliSeconds diff_milliseconds = g_actual_time - SocketTimerGetLastUpdate(
         socket_timer);
 
-      if(diff_milliseconds >=
-         (MilliSeconds) (1000UL * g_tcpip.encapsulation_inactivity_timeout) ) {
+      if( diff_milliseconds >=
+          (MilliSeconds) (1000UL * g_tcpip.encapsulation_inactivity_timeout) ) {
 
         size_t encapsulation_session_handle =
           GetSessionFromSocket(socket_handle);
@@ -1142,8 +1169,7 @@ void CheckEncapsulationInactivity(int socket_handle) {
   }
 }
 
-void RegisterTimeoutChecker(TimeoutCheckerFunction timeout_checker_function)
-{
+void RegisterTimeoutChecker(TimeoutCheckerFunction timeout_checker_function) {
   for (size_t i = 0; i < OPENER_TIMEOUT_CHECKER_ARRAY_SIZE; i++) {
     if (NULL == timeout_checker_array[i]) { // find empty array element
       timeout_checker_array[i] = timeout_checker_function; // add function pointer to array


### PR DESCRIPTION
return message overflow, caused by putting multiple encap commands into one udp message. upon processing the first encap command in the message, skip all others as only one is allowed in there in the first place.