### PR TITLE
POSIX: Add a install target entry

### DIFF
--- a/source/src/ports/POSIX/CMakeLists.txt
+++ b/source/src/ports/POSIX/CMakeLists.txt
@@ -64,3 +64,5 @@ if( NOT OpENer_TESTS)
     message(STATUS "No additional activated objects")
   endif()
 endif()
+
+install (PROGRAMS ${CMAKE_CURRENT_BINARY_DIR}/OpENer DESTINATION ${CMAKE_INSTALL_BINDIR})


### PR DESCRIPTION
While adding OpENer support into OpenEmbedded the following error is seen on the installation phase:

| ninja: error: unknown target 'install'

Fix it by adding a install target so that the OpENer binary can be properly installed.