### PR TITLE
Change comparison for new IO data according to specification

### DIFF
--- a/source/src/cip/cipioconnection.c
+++ b/source/src/cip/cipioconnection.c
@@ -920,8 +920,7 @@ EipStatus HandleReceivedIoConnectionData(CipConnectionObject *connection_object,
       ConnectionObjectGetTransportClassTriggerTransportClass(connection_object) )
   {
     EipUint16 sequence_buffer = GetUintFromMessage( &(data) );
-    if( SEQ_LEQ16(sequence_buffer,
-                  connection_object->sequence_count_consuming) ) {
+    if( sequence_buffer == (connection_object->sequence_count_consuming) ) {
       no_new_data = true;
     }
     connection_object->sequence_count_consuming = sequence_buffer;


### PR DESCRIPTION
A received packet is considered to be new data whenever the CIP Sequence Count is
different (either greater or lesser) than the previous packet’s CIP Sequence Count, Vol2_1.33 3-4.1