### PR TITLE
Add missing length check in EncodeEPath function

### DIFF
--- a/source/src/cip/cipcommon.c
+++ b/source/src/cip/cipcommon.c
@@ -1342,15 +1342,17 @@ void EncodeEPath(const void *const data,
   unsigned int length = epath->path_size;
   size_t start_length = message->used_message_length;
 
-  if(epath->class_id < 256) {
-    AddSintToMessage(0x20, message); /* 8 Bit Class Id */
-    AddSintToMessage( (EipUint8) epath->class_id, message );
-    length -= 1;
-  } else {
-    AddSintToMessage(0x21, message); /*16Bit Class Id */
-    AddSintToMessage(0, message); /*pad byte */
-    AddIntToMessage(epath->class_id, message);
-    length -= 2;
+  if(0 < length) {
+    if(epath->class_id < 256) {
+      AddSintToMessage(0x20, message); /* 8 Bit Class Id */
+      AddSintToMessage( (EipUint8) epath->class_id, message );
+      length -= 1;
+    } else {
+      AddSintToMessage(0x21, message); /*16Bit Class Id */
+      AddSintToMessage(0, message); /*pad byte */
+      AddIntToMessage(epath->class_id, message);
+      length -= 2;
+    }
   }
 
   if(0 < length) {


### PR DESCRIPTION
EncodeEpath assumes that at the very least the Epath it has been given has at least one segment. This is not necessarily true. Take for example the TCP/IP interface object attribute 4. For a device with multiple physical interfaces that correspond to the TCP/IP interface, this attribute can contain a path size of zero.

Without this check the encoding will be wrong and the assertion present in this function will fail.